### PR TITLE
feat: add application icon setting

### DIFF
--- a/App/Sources/AppStorageKey.swift
+++ b/App/Sources/AppStorageKey.swift
@@ -1,0 +1,4 @@
+enum AppStorageKey {
+    static let defaultConnectionCount = "defaultConnectionCount"
+    static let showsMenuBarIcon = "showsMenuBarIcon"
+}

--- a/App/Sources/ContentView.swift
+++ b/App/Sources/ContentView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct ContentView: View {
     @Environment(\.openWindow) private var openWindow
     let service: DownloadService
-    @AppStorage("defaultConnectionCount") private var defaultConnectionCount = 8
+    @AppStorage(AppStorageKey.defaultConnectionCount) private var defaultConnectionCount = 8
     @State private var selection: DownloadFilter? = .all
     @State private var selectedDownloadID: DownloadID?
     @State private var showsNewDownload = false

--- a/App/Sources/MenuBarDownloadsView.swift
+++ b/App/Sources/MenuBarDownloadsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct MenuBarDownloadsView: View {
     @Environment(\.openWindow) private var openWindow
+    @Environment(\.openSettings) private var openSettings
     @Bindable var service: DownloadService
 
     var body: some View {
@@ -15,6 +16,12 @@ struct MenuBarDownloadsView: View {
                 title: "Open Swifty Download Manager",
                 systemImage: "macwindow",
                 action: openMainWindow
+            )
+
+            MenuBarActionRow(
+                title: "Settings…",
+                systemImage: "gearshape",
+                action: openSettingsWindow
             )
 
             Divider()
@@ -33,6 +40,11 @@ struct MenuBarDownloadsView: View {
     private func openMainWindow() {
         NSApp.activate()
         openWindow(id: AppWindowID.main)
+    }
+
+    private func openSettingsWindow() {
+        NSApp.activate()
+        openSettings()
     }
 
     private func exitApplication() {

--- a/App/Sources/SDMApp.swift
+++ b/App/Sources/SDMApp.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct SDMApp: App {
     @NSApplicationDelegateAdaptor(SDMApplicationDelegate.self)
     private var applicationDelegate
+    @AppStorage(AppStorageKey.showsMenuBarIcon) private var showsMenuBarIcon = true
     @State private var downloadService = DownloadService.live()
 
     var body: some Scene {
@@ -18,7 +19,8 @@ struct SDMApp: App {
 
         MenuBarExtra(
             "Swifty Download Manager",
-            image: "SDMMenuBarIcon"
+            image: "SDMMenuBarIcon",
+            isInserted: $showsMenuBarIcon
         ) {
             MenuBarDownloadsView(service: downloadService)
         }

--- a/App/Sources/SettingsView.swift
+++ b/App/Sources/SettingsView.swift
@@ -2,11 +2,22 @@ import SDMCore
 import SwiftUI
 
 struct SettingsView: View {
-    @AppStorage("defaultConnectionCount") private var defaultConnectionCount = 8
+    @AppStorage(AppStorageKey.defaultConnectionCount) private var defaultConnectionCount = 8
+    @AppStorage(AppStorageKey.showsMenuBarIcon) private var showsMenuBarIcon = true
     let databaseURL: URL?
 
     var body: some View {
         Form {
+            Section("General") {
+                Picker("Application icon location", selection: $showsMenuBarIcon) {
+                    Text("In Dock and Menu Bar")
+                        .tag(true)
+                    Text("In Dock only")
+                        .tag(false)
+                }
+                .pickerStyle(.menu)
+            }
+
             Section("Downloads") {
                 Stepper(
                     "Default connections: \(defaultConnectionCount)",
@@ -30,7 +41,7 @@ struct SettingsView: View {
         }
         .formStyle(.grouped)
         .padding()
-        .frame(width: 560, height: 320)
+        .frame(width: 560, height: 360)
     }
 }
 


### PR DESCRIPTION
## Summary

- add a persistent application icon location setting
- allow switching between Dock + Menu Bar and Dock only
- update `MenuBarExtra` visibility immediately when the preference changes
- add a Settings entry to the menu bar panel
- centralize shared `AppStorage` keys

## User impact

Users can choose whether Swifty Download Manager appears in both the Dock and menu bar or only in the Dock. The preference persists across launches.

## Validation

- `xcodebuild test -workspace SDM.xcworkspace -scheme SDMApp -destination platform=macOS -derivedDataPath DerivedData/feature-setting CODE_SIGNING_ALLOWED=NO` — 18 tests passed
- `bash Scripts/test.sh` — 19 fixture tests and 23 SDMCore tests passed
