### PR TITLE
Add Safari download interception extension

### DIFF
--- a/App/Sources/BrowserDownloadRequest.swift
+++ b/App/Sources/BrowserDownloadRequest.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+struct BrowserDownloadRequest: Equatable {
+    static let callbackScheme = "swifty-download-manager"
+
+    let url: URL
+    let suggestedFilename: String?
+    let sourcePageURL: URL?
+
+    init?(callbackURL: URL) {
+        guard callbackURL.scheme?.lowercased() == Self.callbackScheme,
+              callbackURL.host?.lowercased() == "download",
+              let components = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false),
+              let urlText = components.value(forQueryItem: "url"),
+              let url = URL(string: urlText),
+              let scheme = url.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              url.host != nil
+        else {
+            return nil
+        }
+
+        self.url = url
+        suggestedFilename = components.nonEmptyValue(forQueryItem: "filename")
+        sourcePageURL = components
+            .value(forQueryItem: "source")
+            .flatMap(URL.init(string:))
+    }
+}
+
+private extension URLComponents {
+    func value(forQueryItem name: String) -> String? {
+        queryItems?.first { $0.name == name }?.value
+    }
+
+    func nonEmptyValue(forQueryItem name: String) -> String? {
+        guard let value = value(forQueryItem: name)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty
+        else {
+            return nil
+        }
+        return value
+    }
+}

--- a/App/Sources/ContentView.swift
+++ b/App/Sources/ContentView.swift
@@ -74,6 +74,7 @@ struct ContentView: View {
         .onChange(of: selection) { _, _ in
             selectedDownloadID = nil
         }
+        .onOpenURL(perform: handleExternalURL)
         .focusedSceneValue(\.newURLAction, availableNewURLAction)
     }
 
@@ -249,6 +250,25 @@ struct ContentView: View {
 
     private func presentNewDownload() {
         showsNewDownload = true
+    }
+
+    private func handleExternalURL(_ callbackURL: URL) {
+        guard let request = BrowserDownloadRequest(callbackURL: callbackURL) else { return }
+
+        Task { @MainActor in
+            do {
+                _ = try await service.enqueue(
+                    url: request.url,
+                    suggestedFilename: request.suggestedFilename,
+                    connectionCount: defaultConnectionCount
+                )
+            } catch {
+                presentedError = PresentedDownloadError(
+                    title: "Could Not Add Browser Download",
+                    error: error
+                )
+            }
+        }
     }
 }
 

--- a/App/Sources/DownloadService.swift
+++ b/App/Sources/DownloadService.swift
@@ -102,6 +102,7 @@ final class DownloadService {
     func enqueue(
         url: URL,
         destinationDirectory: URL? = nil,
+        suggestedFilename: String? = nil,
         connectionCount: Int
     ) async throws -> DownloadID {
         let manager = try requiredManager()
@@ -123,6 +124,7 @@ final class DownloadService {
         let request = DownloadRequest(
             url: url,
             destinationDirectory: authorizedDestination,
+            filename: suggestedFilename,
             connectionLimit: connectionCount
         )
         return try await manager.enqueue(request)

--- a/App/Sources/SafariExtensionSupport.swift
+++ b/App/Sources/SafariExtensionSupport.swift
@@ -3,6 +3,21 @@ import SafariServices
 enum SafariExtensionSupport {
     static let bundleIdentifier = "top.kyleye.swifty-download-manager-app.safari-extension"
 
+    nonisolated static func isEnabled() async -> Bool? {
+        await withCheckedContinuation { continuation in
+            // The SDK marks this completion as UI-actor-isolated, but SafariServices
+            // invokes it on an XPC queue. Keep the closure itself nonisolated and send
+            // only the value across the continuation boundary.
+            let completion: @Sendable (SFSafariExtensionState?, Error?) -> Void = { state, _ in
+                continuation.resume(returning: state?.isEnabled)
+            }
+            SFSafariExtensionManager.getStateOfSafariExtension(
+                withIdentifier: bundleIdentifier,
+                completionHandler: completion
+            )
+        }
+    }
+
     static func showPreferences() {
         SFSafariApplication.showPreferencesForExtension(
             withIdentifier: bundleIdentifier,

--- a/App/Sources/SafariExtensionSupport.swift
+++ b/App/Sources/SafariExtensionSupport.swift
@@ -1,0 +1,12 @@
+import SafariServices
+
+enum SafariExtensionSupport {
+    static let bundleIdentifier = "top.kyleye.swifty-download-manager-app.safari-extension"
+
+    static func showPreferences() {
+        SFSafariApplication.showPreferencesForExtension(
+            withIdentifier: bundleIdentifier,
+            completionHandler: nil
+        )
+    }
+}

--- a/App/Sources/SettingsView.swift
+++ b/App/Sources/SettingsView.swift
@@ -1,5 +1,5 @@
 import SDMCore
-import SafariServices
+import AppKit
 import SwiftUI
 
 struct SettingsView: View {
@@ -60,10 +60,12 @@ struct SettingsView: View {
         .padding()
         .frame(width: 560, height: 470)
         .task {
-            refreshSafariExtensionState()
+            await refreshSafariExtensionState()
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
-            refreshSafariExtensionState()
+            Task {
+                await refreshSafariExtensionState()
+            }
         }
     }
 
@@ -83,12 +85,8 @@ struct SettingsView: View {
         }
     }
 
-    private func refreshSafariExtensionState() {
-        SFSafariExtensionManager.getStateOfSafariExtension(
-            withIdentifier: SafariExtensionSupport.bundleIdentifier
-        ) { state, _ in
-            safariExtensionIsEnabled = state?.isEnabled
-        }
+    private func refreshSafariExtensionState() async {
+        safariExtensionIsEnabled = await SafariExtensionSupport.isEnabled()
     }
 }
 

--- a/App/Sources/SettingsView.swift
+++ b/App/Sources/SettingsView.swift
@@ -1,9 +1,11 @@
 import SDMCore
+import SafariServices
 import SwiftUI
 
 struct SettingsView: View {
     @AppStorage(AppStorageKey.defaultConnectionCount) private var defaultConnectionCount = 8
     @AppStorage(AppStorageKey.showsMenuBarIcon) private var showsMenuBarIcon = true
+    @State private var safariExtensionIsEnabled: Bool?
     let databaseURL: URL?
 
     var body: some View {
@@ -26,6 +28,21 @@ struct SettingsView: View {
                 )
             }
 
+            Section("Safari Extension") {
+                LabeledContent("Status") {
+                    Text(extensionStatusTitle)
+                        .foregroundStyle(extensionStatusColor)
+                }
+
+                Text("Enable the extension in Safari, then allow website access. Download links and the Download with SDM context menu will send supported HTTP and HTTPS files to SDM.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+
+                Button("Open Safari Extension Settings") {
+                    SafariExtensionSupport.showPreferences()
+                }
+            }
+
             Section("Engine") {
                 LabeledContent("Version", value: SDMCoreInfo.engineVersion)
                 LabeledContent("ABI", value: String(SDMCoreInfo.engineABIVersion))
@@ -41,7 +58,37 @@ struct SettingsView: View {
         }
         .formStyle(.grouped)
         .padding()
-        .frame(width: 560, height: 360)
+        .frame(width: 560, height: 470)
+        .task {
+            refreshSafariExtensionState()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            refreshSafariExtensionState()
+        }
+    }
+
+    private var extensionStatusTitle: String {
+        switch safariExtensionIsEnabled {
+        case true: "Enabled"
+        case false: "Disabled"
+        case nil: "Checking…"
+        }
+    }
+
+    private var extensionStatusColor: Color {
+        switch safariExtensionIsEnabled {
+        case true: .green
+        case false: .secondary
+        case nil: .secondary
+        }
+    }
+
+    private func refreshSafariExtensionState() {
+        SFSafariExtensionManager.getStateOfSafariExtension(
+            withIdentifier: SafariExtensionSupport.bundleIdentifier
+        ) { state, _ in
+            safariExtensionIsEnabled = state?.isEnabled
+        }
     }
 }
 

--- a/App/Tests/SDMAppTests.swift
+++ b/App/Tests/SDMAppTests.swift
@@ -6,6 +6,11 @@ import XCTest
 
 final class SDMAppTests: XCTestCase {
     @MainActor
+    func testSafariExtensionStateLookupReturnsAcrossTheXPCBoundary() async {
+        _ = await SafariExtensionSupport.isEnabled()
+    }
+
+    @MainActor
     func testDestinationBookmarkStorePersistsAndRestoresFolderReference() throws {
         let root = FileManager.default.temporaryDirectory.appending(
             path: UUID().uuidString,

--- a/App/Tests/SDMAppTests.swift
+++ b/App/Tests/SDMAppTests.swift
@@ -82,6 +82,40 @@ final class SDMAppTests: XCTestCase {
         XCTAssertEqual(request.connectionLimit, 8)
     }
 
+    func testBrowserDownloadRequestParsesExtensionCallback() throws {
+        var components = URLComponents()
+        components.scheme = BrowserDownloadRequest.callbackScheme
+        components.host = "download"
+        components.queryItems = [
+            URLQueryItem(name: "url", value: "https://example.com/archive.zip?token=a&b=2"),
+            URLQueryItem(name: "filename", value: "release.zip"),
+            URLQueryItem(name: "source", value: "https://example.com/releases"),
+        ]
+
+        let request = try XCTUnwrap(
+            components.url.flatMap(BrowserDownloadRequest.init(callbackURL:))
+        )
+
+        XCTAssertEqual(request.url.absoluteString, "https://example.com/archive.zip?token=a&b=2")
+        XCTAssertEqual(request.suggestedFilename, "release.zip")
+        XCTAssertEqual(request.sourcePageURL?.absoluteString, "https://example.com/releases")
+    }
+
+    func testBrowserDownloadRequestRejectsUntrustedRoutesAndSchemes() throws {
+        let wrongRoute = try XCTUnwrap(
+            URL(string: "swifty-download-manager://settings?url=https://example.com/file.zip")
+        )
+        var components = URLComponents()
+        components.scheme = BrowserDownloadRequest.callbackScheme
+        components.host = "download"
+        components.queryItems = [
+            URLQueryItem(name: "url", value: "file:///tmp/private.txt"),
+        ]
+
+        XCTAssertNil(BrowserDownloadRequest(callbackURL: wrongRoute))
+        XCTAssertNil(components.url.flatMap(BrowserDownloadRequest.init(callbackURL:)))
+    }
+
     func testFiltersClassifyDownloadStates() {
         XCTAssertTrue(DownloadFilter.downloading.includes(.probing))
         XCTAssertTrue(DownloadFilter.downloading.includes(.downloading))

--- a/Project.swift
+++ b/Project.swift
@@ -29,6 +29,13 @@ let project = Project(
                 "CFBundleName": "$(PRODUCT_NAME)",
                 "CFBundlePackageType": "APPL",
                 "CFBundleShortVersionString": "0.1.0",
+                "CFBundleURLTypes": [
+                    [
+                        "CFBundleTypeRole": "Editor",
+                        "CFBundleURLName": "top.kyleye.swifty-download-manager.download",
+                        "CFBundleURLSchemes": ["swifty-download-manager"],
+                    ],
+                ],
                 "CFBundleVersion": "1",
                 "LSApplicationCategoryType": "public.app-category.productivity",
                 "LSMinimumSystemVersion": "$(MACOSX_DEPLOYMENT_TARGET)",
@@ -40,6 +47,7 @@ let project = Project(
             ],
             entitlements: .file(path: "App/Support/SDMApp.entitlements"),
             dependencies: [
+                .target(name: "SDMSafariExtension"),
                 .external(name: "SDMCore"),
             ],
             settings: .settings(base: [
@@ -53,6 +61,44 @@ let project = Project(
             metadata: .metadata(tags: [
                 "tag:feature:downloads",
                 "tag:layer:ui",
+            ])
+        ),
+        .target(
+            name: "SDMSafariExtension",
+            destinations: .macOS,
+            product: .appExtension,
+            bundleId: "top.kyleye.swifty-download-manager-app.safari-extension",
+            deploymentTargets: .macOS("14.0"),
+            infoPlist: .dictionary([
+                "CFBundleDevelopmentRegion": "en",
+                "CFBundleDisplayName": "Swifty Download Manager Extension",
+                "CFBundleExecutable": "$(EXECUTABLE_NAME)",
+                "CFBundleIdentifier": "$(PRODUCT_BUNDLE_IDENTIFIER)",
+                "CFBundleInfoDictionaryVersion": "6.0",
+                "CFBundleName": "$(PRODUCT_NAME)",
+                "CFBundlePackageType": "XPC!",
+                "CFBundleShortVersionString": "0.1.0",
+                "CFBundleVersion": "1",
+                "LSMinimumSystemVersion": "$(MACOSX_DEPLOYMENT_TARGET)",
+                "NSExtension": [
+                    "NSExtensionPointIdentifier": "com.apple.Safari.web-extension",
+                    "NSExtensionPrincipalClass": "$(PRODUCT_MODULE_NAME).SafariWebExtensionHandler",
+                ],
+            ]),
+            buildableFolders: [
+                "SafariExtension/Sources",
+                "SafariExtension/Resources",
+            ],
+            entitlements: .file(path: "SafariExtension/Support/SDMSafariExtension.entitlements"),
+            settings: .settings(base: [
+                "APPLICATION_EXTENSION_API_ONLY": "YES",
+                "CODE_SIGN_STYLE": "Automatic",
+                "PRODUCT_NAME": "Swifty Download Manager Extension",
+                "SKIP_INSTALL": "YES",
+            ]),
+            metadata: .metadata(tags: [
+                "tag:feature:browser-extension",
+                "tag:layer:integration",
             ])
         ),
         .target(

--- a/README.md
+++ b/README.md
@@ -50,6 +50,20 @@ bash Scripts/test.sh
 Swift integration tests start isolated Fixture processes on ephemeral loopback
 ports and clean them up automatically.
 
+## Safari extension
+
+The macOS app embeds a Safari Web Extension that sends direct HTTP and HTTPS
+download links to SDM. Run the containing app once, open **Settings > Safari
+Extension**, enable it in Safari, and grant access to the websites where it
+should operate. Links with a `download` attribute and common downloadable file
+extensions are captured automatically. Use **Download with SDM** from Safari's
+link context menu for download endpoints without a recognizable filename.
+
+Holding a modifier key while clicking bypasses SDM and preserves Safari's
+normal link handling. This first version forwards direct GET URLs and suggested
+filenames; authenticated requests that depend on browser-only cookies or custom
+headers are not yet transferred.
+
 ## Local HTTP fixture
 
 Run the threaded Range server used by download-engine integration tests:

--- a/SafariExtension/Resources/background.js
+++ b/SafariExtension/Resources/background.js
@@ -1,0 +1,72 @@
+const extensionAPI = globalThis.browser ?? globalThis.chrome;
+const nativeApplicationIdentifier = "top.kyleye.swifty-download-manager-app";
+const contextMenuIdentifier = "download-with-sdm";
+
+function isHTTPURL(value) {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+async function sendToApp(message) {
+  try {
+    const response = await extensionAPI.runtime.sendNativeMessage(
+      nativeApplicationIdentifier,
+      message
+    );
+    return response ?? { accepted: false, error: "SDM did not respond." };
+  } catch (error) {
+    return {
+      accepted: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function registerContextMenu() {
+  try {
+    await extensionAPI.contextMenus.removeAll();
+    extensionAPI.contextMenus.create({
+      id: contextMenuIdentifier,
+      title: "Download with SDM",
+      contexts: ["link"],
+      targetUrlPatterns: ["http://*/*", "https://*/*"],
+    });
+  } catch (error) {
+    console.error("Unable to register the SDM context menu", error);
+  }
+}
+
+extensionAPI.runtime.onMessage.addListener((message, sender) => {
+  if (message?.type !== "captureDownload" || !isHTTPURL(message.url)) {
+    return undefined;
+  }
+
+  return sendToApp({
+    type: "download",
+    url: message.url,
+    filename: message.filename,
+    sourcePage: message.sourcePage ?? sender?.tab?.url,
+  });
+});
+
+extensionAPI.contextMenus.onClicked.addListener((info, tab) => {
+  if (info.menuItemId !== contextMenuIdentifier || !isHTTPURL(info.linkUrl)) {
+    return;
+  }
+
+  void sendToApp({
+    type: "download",
+    url: info.linkUrl,
+    sourcePage: info.pageUrl ?? tab?.url,
+  });
+});
+
+extensionAPI.browserAction.onClicked.addListener(() => {
+  void sendToApp({ type: "openApp" });
+});
+
+void registerContextMenu();

--- a/SafariExtension/Resources/content.js
+++ b/SafariExtension/Resources/content.js
@@ -1,0 +1,90 @@
+(() => {
+  const extensionAPI = globalThis.browser ?? globalThis.chrome;
+  const downloadableExtensions = new Set([
+    "7z", "aac", "apk", "app", "arc", "arj", "avi", "bin", "bz2", "cab",
+    "csv", "dmg", "doc", "docx", "epub", "exe", "flac", "gz", "img", "iso",
+    "jar", "key", "m4a", "m4v", "mkv", "mov", "mp3", "mp4", "mpeg", "mpg",
+    "msi", "numbers", "odf", "ods", "odt", "pages", "pdf", "pkg", "ppt",
+    "pptx", "rar", "rtf", "tar", "tgz", "tif", "tiff", "ts", "txt", "wav",
+    "webm", "wma", "wmv", "xls", "xlsx", "xip", "xz", "zip", "zipx"
+  ]);
+
+  function linkFromEvent(event) {
+    for (const node of event.composedPath()) {
+      if (node instanceof HTMLAnchorElement || node instanceof HTMLAreaElement) {
+        return node;
+      }
+    }
+    return null;
+  }
+
+  function parsedHTTPURL(value) {
+    try {
+      const url = new URL(value, document.baseURI);
+      return url.protocol === "http:" || url.protocol === "https:" ? url : null;
+    } catch {
+      return null;
+    }
+  }
+
+  function inferredExtension(url) {
+    const name = url.pathname.split("/").pop() ?? "";
+    const separator = name.lastIndexOf(".");
+    return separator >= 0 ? name.slice(separator + 1).toLowerCase() : "";
+  }
+
+  function isDownloadLink(link, url) {
+    return link.hasAttribute("download") || downloadableExtensions.has(inferredExtension(url));
+  }
+
+  function suggestedFilename(link) {
+    if (!(link instanceof HTMLAnchorElement) || !link.hasAttribute("download")) {
+      return undefined;
+    }
+    const value = link.getAttribute("download")?.trim();
+    return value || undefined;
+  }
+
+  function resumeNavigation(link, url) {
+    if (link.target === "_blank") {
+      window.open(url.href, "_blank", "noopener");
+    } else {
+      window.location.assign(url.href);
+    }
+  }
+
+  document.addEventListener("click", (event) => {
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.shiftKey
+    ) {
+      return;
+    }
+
+    const link = linkFromEvent(event);
+    const url = link ? parsedHTTPURL(link.href) : null;
+    if (!link || !url || !isDownloadLink(link, url)) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopImmediatePropagation();
+
+    Promise.resolve(extensionAPI.runtime.sendMessage({
+      type: "captureDownload",
+      url: url.href,
+      filename: suggestedFilename(link),
+      sourcePage: window.location.href,
+    })).then((response) => {
+      if (!response?.accepted) {
+        resumeNavigation(link, url);
+      }
+    }).catch(() => {
+      resumeNavigation(link, url);
+    });
+  }, true);
+})();

--- a/SafariExtension/Resources/icon.svg
+++ b/SafariExtension/Resources/icon.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="28" fill="#1769e0"/>
+  <g fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="10">
+    <path d="M64 25v56"/>
+    <path d="m43 61 21 21 21-21"/>
+    <path d="M29 87v8c0 7 6 13 13 13h44c7 0 13-6 13-13v-8"/>
+  </g>
+</svg>

--- a/SafariExtension/Resources/manifest.json
+++ b/SafariExtension/Resources/manifest.json
@@ -1,0 +1,40 @@
+{
+  "manifest_version": 2,
+  "name": "Swifty Download Manager",
+  "description": "Send downloadable links from Safari to Swifty Download Manager.",
+  "version": "0.1.0",
+  "icons": {
+    "16": "icon.svg",
+    "32": "icon.svg",
+    "48": "icon.svg",
+    "128": "icon.svg"
+  },
+  "background": {
+    "scripts": [
+      "background.js"
+    ],
+    "persistent": true
+  },
+  "browser_action": {
+    "default_icon": "icon.svg",
+    "default_title": "Open Swifty Download Manager"
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "http://*/*",
+        "https://*/*"
+      ],
+      "js": [
+        "content.js"
+      ],
+      "run_at": "document_start",
+      "all_frames": true
+    }
+  ],
+  "permissions": [
+    "<all_urls>",
+    "contextMenus",
+    "nativeMessaging"
+  ]
+}

--- a/SafariExtension/Sources/SafariWebExtensionHandler.swift
+++ b/SafariExtension/Sources/SafariWebExtensionHandler.swift
@@ -1,0 +1,94 @@
+import AppKit
+import SafariServices
+
+final class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
+    private static let callbackScheme = "swifty-download-manager"
+
+    func beginRequest(with context: NSExtensionContext) {
+        guard let item = context.inputItems.first as? NSExtensionItem,
+              let userInfo = item.userInfo as? [String: Any],
+              let message = userInfo[SFExtensionMessageKey] as? [String: Any]
+        else {
+            reply(to: context, accepted: false, error: "The extension message was invalid.")
+            return
+        }
+
+        switch message["type"] as? String {
+        case "download":
+            handleDownload(message, context: context)
+        case "openApp":
+            openCallback(host: "open", queryItems: [], context: context)
+        default:
+            reply(to: context, accepted: false, error: "The extension message type was unsupported.")
+        }
+    }
+
+    private func handleDownload(
+        _ message: [String: Any],
+        context: NSExtensionContext
+    ) {
+        guard let urlText = message["url"] as? String,
+              let downloadURL = URL(string: urlText),
+              let scheme = downloadURL.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              downloadURL.host != nil
+        else {
+            reply(to: context, accepted: false, error: "Only HTTP and HTTPS downloads are supported.")
+            return
+        }
+
+        var queryItems = [URLQueryItem(name: "url", value: downloadURL.absoluteString)]
+        if let filename = nonEmptyString(message["filename"]) {
+            queryItems.append(URLQueryItem(name: "filename", value: filename))
+        }
+        if let sourcePage = nonEmptyString(message["sourcePage"]) {
+            queryItems.append(URLQueryItem(name: "source", value: sourcePage))
+        }
+
+        openCallback(host: "download", queryItems: queryItems, context: context)
+    }
+
+    private func openCallback(
+        host: String,
+        queryItems: [URLQueryItem],
+        context: NSExtensionContext
+    ) {
+        var components = URLComponents()
+        components.scheme = Self.callbackScheme
+        components.host = host
+        components.queryItems = queryItems.isEmpty ? nil : queryItems
+
+        guard let callbackURL = components.url else {
+            reply(to: context, accepted: false, error: "The app callback URL could not be created.")
+            return
+        }
+
+        let accepted = NSWorkspace.shared.open(callbackURL)
+        reply(
+            to: context,
+            accepted: accepted,
+            error: accepted ? nil : "Swifty Download Manager could not be opened."
+        )
+    }
+
+    private func reply(
+        to context: NSExtensionContext,
+        accepted: Bool,
+        error: String?
+    ) {
+        var message: [String: Any] = ["accepted": accepted]
+        if let error {
+            message["error"] = error
+        }
+
+        let response = NSExtensionItem()
+        response.userInfo = [SFExtensionMessageKey: message]
+        context.completeRequest(returningItems: [response])
+    }
+
+    private func nonEmptyString(_ value: Any?) -> String? {
+        guard let value = value as? String else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/SafariExtension/Support/SDMSafariExtension.entitlements
+++ b/SafariExtension/Support/SDMSafariExtension.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- add an embedded Safari Web Extension that intercepts supported HTTP and HTTPS download links
- provide a “Download with SDM” context menu and forward requests to the macOS app
- add Safari Extension status and settings access to the app
- add callback parsing, tests, documentation, and a concurrency-safe Safari extension state query

## Why

Safari users need browser-level download interception so supported downloads can be handed directly to SDM. Chrome Extension support remains out of scope for this change.

## Validation

- regenerated the Tuist workspace successfully
- ran `SDMAppTests` with `xcodebuild test`
- installed the containing app and enabled its unsigned Safari extension
- verified on a local HTTP test page that Safari stayed on the page while SDM received and completed the download
