### PR TITLE
Add FSL-1.1-MIT licensing

### DIFF
--- a/BRANDING.md
+++ b/BRANDING.md
@@ -1,0 +1,23 @@
+# Brand and visual assets
+
+The FSL-1.1-MIT license in [`LICENSE.md`](LICENSE.md) applies to the source code
+and documentation in this repository, except for the brand and visual assets
+identified below.
+
+"Swifty Download Manager", its app icon, menu bar icon, Safari extension icon,
+and the associated visual identity are Copyright 2026 Kyle Ye. All rights
+reserved. The excluded asset paths are:
+
+- `App/Resources/AppIcon.icon/`
+- `App/Resources/Assets.xcassets/SDMMenuBarIcon.imageset/`
+- `Design/AppIcon/`
+- `SafariExtension/Resources/icon.svg`
+
+You may copy these assets only as necessary to build and run the Software for
+personal use, internal evaluation, testing, or contributing changes to this
+repository. This limited permission does not allow their use in a redistributed
+application, public release, store listing, product, service, or branding
+without prior written permission from the copyright holder.
+
+Nothing in the Software license grants trademark rights or permission to imply
+endorsement by, or affiliation with, the Swifty Download Manager project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing to Swifty Download Manager
+
+Thank you for contributing to Swifty Download Manager. Please open an issue or
+discussion before investing significant time in a large change.
+
+## Contribution terms
+
+The project source is made available under the Functional Source License,
+Version 1.1, MIT Future License (`FSL-1.1-MIT`). By submitting a contribution,
+you represent that you have the right to submit it and agree that:
+
+1. Your contribution is provided under `FSL-1.1-MIT`, including its automatic
+   MIT grant two years after the contribution is made available.
+2. You grant the Licensor identified in [`LICENSE.md`](LICENSE.md) a perpetual,
+   worldwide, non-exclusive, irrevocable, royalty-free license to use,
+   reproduce, modify, distribute, sublicense, and include the contribution in
+   official builds of Swifty Download Manager, including builds distributed
+   through the App Store under applicable end-user terms.
+3. This grant does not transfer ownership of your contribution to the Licensor.
+
+Submitting a contribution does not grant any right to use the project's name,
+icons, or other brand assets. See [`BRANDING.md`](BRANDING.md).
+
+## Development workflow
+
+Keep changes focused, include tests when behavior changes, and run the complete
+local validation suite before requesting review:
+
+```bash
+bash Scripts/test.sh
+```

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,110 @@
+# Functional Source License, Version 1.1, MIT Future License
+
+## Abbreviation
+
+FSL-1.1-MIT
+
+## Notice
+
+Copyright 2026 Kyle Ye
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the MIT license that is effective on the second anniversary of the date we make
+the Software available. On or after that date, you may use the Software under
+the MIT license, in which case the following will apply:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,23 @@ for lifecycle and integration guidance.
 - Framework bundle identifier: `top.kyleye.swifty-download-manager`
 - App bundle identifier: `top.kyleye.swifty-download-manager-app`
 
+## License
+
+The source code and documentation in this repository are available under the
+[Functional Source License, Version 1.1, MIT Future License](LICENSE.md). You
+may use, study, modify, and redistribute the Software for any permitted purpose,
+but may not offer it as a competing commercial product or service. Each version
+automatically becomes available under the MIT License two years after it is
+made available.
+
+This is a Fair Source license; a version becomes Open Source when its future MIT
+license takes effect. The Swifty Download Manager name, icons, and visual assets
+are excluded from the Software license as described in [`BRANDING.md`](BRANDING.md).
+Official App Store builds may be distributed under separate end-user terms.
+
+Contributions are accepted under the terms in
+[`CONTRIBUTING.md`](CONTRIBUTING.md).
+
 ## Reference material
 
 The locally supplied NDM application and screenshots are research inputs only.


### PR DESCRIPTION
## Summary

- license the source under FSL-1.1-MIT, with each version automatically becoming MIT after two years
- reserve the Swifty Download Manager name and identified visual assets
- document contribution terms that cover official App Store builds
- explain the licensing model in the README

## Why

This keeps the source available for use, study, modification, and contribution while protecting the commercial App Store product from competing use during each version's first two years.

## Impact

There are no runtime or build changes. Users and contributors now have explicit licensing, brand-use, and contribution terms.

## Validation

- `git diff --cached --check`
- verified every excluded brand asset path exists
- application tests not run (documentation and licensing only)
