### PR TITLE
Fix segmented and programmatic Safari downloads

### DIFF
--- a/App/Sources/BrowserDownloadRequest.swift
+++ b/App/Sources/BrowserDownloadRequest.swift
@@ -1,5 +1,11 @@
 import Foundation
 
+extension Notification.Name {
+    static let browserDownloadCallback = Notification.Name(
+        "top.kyleye.swifty-download-manager.browser-callback"
+    )
+}
+
 struct BrowserDownloadRequest: Equatable {
     static let callbackScheme = "swifty-download-manager"
 

--- a/App/Sources/ContentView.swift
+++ b/App/Sources/ContentView.swift
@@ -66,6 +66,12 @@ struct ContentView: View {
             selectedDownloadID = nil
         }
         .onOpenURL(perform: handleExternalURL)
+        .onReceive(
+            NotificationCenter.default.publisher(for: .browserDownloadCallback)
+        ) { notification in
+            guard let callbackURL = notification.object as? URL else { return }
+            handleExternalURL(callbackURL)
+        }
         .focusedSceneValue(\.newURLAction, availableNewURLAction)
     }
 

--- a/App/Sources/SDMApplicationDelegate.swift
+++ b/App/Sources/SDMApplicationDelegate.swift
@@ -3,10 +3,46 @@ import AppKit
 
 @MainActor
 final class SDMApplicationDelegate: NSObject, NSApplicationDelegate {
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        DistributedNotificationCenter.default().addObserver(
+            self,
+            selector: #selector(handleBrowserCallback(_:)),
+            name: .browserDownloadCallback,
+            object: nil,
+            suspensionBehavior: .deliverImmediately
+        )
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        DistributedNotificationCenter.default().removeObserver(
+            self,
+            name: .browserDownloadCallback,
+            object: nil
+        )
+    }
+
     func applicationShouldTerminateAfterLastWindowClosed(
         _ sender: NSApplication
     ) -> Bool {
         false
+    }
+
+    @objc private func handleBrowserCallback(_ notification: Notification) {
+        guard let callbackText = notification.object as? String,
+              let callbackURL = URL(string: callbackText),
+              callbackURL.scheme?.lowercased() == BrowserDownloadRequest.callbackScheme
+        else {
+            return
+        }
+
+        if callbackURL.host?.lowercased() == "open" {
+            NSApplication.shared.activate()
+        } else if BrowserDownloadRequest(callbackURL: callbackURL) != nil {
+            NotificationCenter.default.post(
+                name: .browserDownloadCallback,
+                object: callbackURL
+            )
+        }
     }
 }
 #else

--- a/Fixture/README.md
+++ b/Fixture/README.md
@@ -20,7 +20,8 @@ following fields can be changed there:
 | --- | --- |
 | `host` | Listening interface |
 | `port` | Listening TCP port |
-| `max_connections` | Concurrent file transfers and ranges per request |
+| `max_concurrent_transfers` | Response bodies the server transfers concurrently |
+| `max_ranges_per_request` | Byte ranges accepted in one `Range` request |
 | `file_size` | Virtual `/empty.bin` size in bytes |
 | `bytes_per_second` | `/empty.bin` transfer rate per connection |
 | `chunk_size` | `/empty.bin` streaming write size |
@@ -29,7 +30,8 @@ CLI arguments can override the main multi-connection fields for one run:
 
 ```bash
 python3 Fixture/range_server.py \
-  --max-connections <count> \
+  --max-concurrent-transfers <count> \
+  --max-ranges-per-request <count> \
   --file-size <bytes> \
   --bytes-per-second <bytes-per-second>
 ```
@@ -62,23 +64,32 @@ bounds without creating or allocating a matching file on disk. The pattern
 makes misplaced, overlapping, or missing segment writes visible in
 byte-for-byte tests.
 
-## Connection and Range limits
+## Transfer and Range limits
 
-`max_connections` limits both:
+`max_concurrent_transfers` is a server-side capacity limit. Clients can open
+more connections and send more Range requests, but only this many response
+bodies are transferred at once; excess requests wait for a server slot. This
+models an HTTP/1.1 origin that accepts more work than it can process
+concurrently.
 
-- the number of file response bodies that the server transfers concurrently;
-- the number of comma-separated ranges accepted in one `Range` request.
+There is no HTTP/1.1 response header that negotiates a server-wide connection
+limit. [RFC 9112, Section 9.4](https://www.rfc-editor.org/rfc/rfc9112.html#section-9.4)
+asks clients to be conservative but deliberately defines no fixed maximum.
+HTTP/2 has
+[`SETTINGS_MAX_CONCURRENT_STREAMS`](https://www.rfc-editor.org/rfc/rfc9113.html#section-6.5.2),
+but that setting applies only to streams on one HTTP/2 connection and is not an
+HTTP response header.
 
-Requests beyond the concurrent connection limit wait for a slot. A request
-containing too many ranges receives `400`; an unsatisfiable range receives
-`416` with `Content-Range: bytes */<size>`. Multiple satisfiable ranges receive
-a standards-compatible `multipart/byteranges` body.
+`max_ranges_per_request` independently limits comma-separated ranges within a
+single request. A request containing too many ranges receives `400`; an
+unsatisfiable range receives `416` with `Content-Range: bytes */<size>`.
+Multiple satisfiable ranges receive a standards-compatible
+`multipart/byteranges` body.
 
-The response header `X-SDM-Max-Connections` exposes the configured limit for
-fixture diagnostics. It is not a standard HTTP negotiation header. HTTP only
-lets a server advertise range support using `Accept-Ranges: bytes`; the client
-still decides how many connections to open. Therefore the configured maximum
-is a ceiling, not a guarantee that NDM or SDM will create that many connections.
+Range-capable resources advertise only the standard `Accept-Ranges: bytes`
+field. Per [RFC 9110, Section 14.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-14.3),
+that field advises that byte ranges are supported; it does not advertise a
+connection count or guarantee that every future request will receive `206`.
 
 For NDM multi-connection testing, use `/empty.bin`.
 
@@ -103,4 +114,5 @@ python3 -m unittest discover -s Fixture/tests -v
 
 The test suite verifies configuration, virtual-file streaming, single and
 multipart ranges, persistent connections, multi-part reconstruction,
-throttling, and enforcement of the concurrent transfer limit.
+throttling, and that 32 simultaneous client requests are queued through an
+eight-transfer server pool.

--- a/Fixture/config.json
+++ b/Fixture/config.json
@@ -1,7 +1,8 @@
 {
   "host": "127.0.0.1",
   "port": 8080,
-  "max_connections": 8,
+  "max_concurrent_transfers": 8,
+  "max_ranges_per_request": 8,
   "file_size": 83886080,
   "bytes_per_second": 1048576,
   "chunk_size": 16384

--- a/Fixture/range_server.py
+++ b/Fixture/range_server.py
@@ -19,7 +19,8 @@ from urllib.parse import urlsplit
 DEFAULT_CONFIG_PATH = Path(__file__).with_name("config.json")
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8080
-DEFAULT_MAX_CONNECTIONS = 8
+DEFAULT_MAX_CONCURRENT_TRANSFERS = 8
+DEFAULT_MAX_RANGES_PER_REQUEST = 8
 DEFAULT_FILE_SIZE = 80 * 1024 * 1024
 DEFAULT_BYTES_PER_SECOND = 1024 * 1024
 DEFAULT_CHUNK_SIZE = 16 * 1024
@@ -60,7 +61,8 @@ class FixtureConfig:
 
     host: str = DEFAULT_HOST
     port: int = DEFAULT_PORT
-    max_connections: int = DEFAULT_MAX_CONNECTIONS
+    max_concurrent_transfers: int = DEFAULT_MAX_CONCURRENT_TRANSFERS
+    max_ranges_per_request: int = DEFAULT_MAX_RANGES_PER_REQUEST
     file_size: int = DEFAULT_FILE_SIZE
     bytes_per_second: int = DEFAULT_BYTES_PER_SECOND
     chunk_size: int = DEFAULT_CHUNK_SIZE
@@ -69,8 +71,10 @@ class FixtureConfig:
     def __post_init__(self) -> None:
         if not 0 <= self.port <= 65535:
             raise ValueError("port must be between 0 and 65535")
-        if self.max_connections <= 0:
-            raise ValueError("max_connections must be positive")
+        if self.max_concurrent_transfers <= 0:
+            raise ValueError("max_concurrent_transfers must be positive")
+        if self.max_ranges_per_request <= 0:
+            raise ValueError("max_ranges_per_request must be positive")
         if self.file_size <= 0:
             raise ValueError("file_size must be positive")
         if self.bytes_per_second < 0:
@@ -197,10 +201,13 @@ class FixtureHTTPServer(ThreadingHTTPServer):
 
     daemon_threads = True
     allow_reuse_address = True
+    request_queue_size = 64
 
     def __init__(self, config: FixtureConfig) -> None:
         self.config = config
-        self._transfer_slots = threading.BoundedSemaphore(config.max_connections)
+        self._transfer_slots = threading.BoundedSemaphore(
+            config.max_concurrent_transfers
+        )
         self._transfer_count_lock = threading.Lock()
         self.active_transfers = 0
         self.peak_active_transfers = 0
@@ -403,7 +410,7 @@ class FixtureRequestHandler(BaseHTTPRequestHandler):
                 parse_byte_ranges(
                     range_header,
                     resource.size,
-                    max_ranges=self.fixture_server.config.max_connections,
+                    max_ranges=self.fixture_server.config.max_ranges_per_request,
                 )
                 if range_header
                 else []
@@ -523,13 +530,6 @@ class FixtureRequestHandler(BaseHTTPRequestHandler):
         self.send_header("ETag", resource.etag)
         self.send_header("Last-Modified", EMPTY_FILE_LAST_MODIFIED)
         self.send_header("Cache-Control", "no-store")
-        self.send_header(
-            "X-SDM-Max-Connections",
-            str(
-                self.fixture_server.config.max_connections
-                if resource.supports_ranges else 1
-            ),
-        )
         self.send_header("X-SDM-Bytes-Per-Second", str(resource.bytes_per_second))
 
     def _send_empty_response(self, status: int) -> None:
@@ -620,7 +620,7 @@ class FixtureRequestHandler(BaseHTTPRequestHandler):
         active = self.fixture_server.active_transfers
         sys.stderr.write(
             f"{self.address_string()} [{active}/"
-            f"{self.fixture_server.config.max_connections}] "
+            f"{self.fixture_server.config.max_concurrent_transfers}] "
             f"Range={range_header} - {format % args}\n"
         )
 
@@ -638,7 +638,8 @@ def _load_runtime_config(args: argparse.Namespace) -> FixtureConfig:
         for name, value in {
             "host": args.host,
             "port": args.port,
-            "max_connections": args.max_connections,
+            "max_concurrent_transfers": args.max_concurrent_transfers,
+            "max_ranges_per_request": args.max_ranges_per_request,
             "file_size": args.file_size,
             "bytes_per_second": args.bytes_per_second,
             "chunk_size": args.chunk_size,
@@ -654,7 +655,8 @@ def main() -> None:
     parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG_PATH)
     parser.add_argument("--host")
     parser.add_argument("--port", type=int)
-    parser.add_argument("--max-connections", type=int)
+    parser.add_argument("--max-concurrent-transfers", type=int)
+    parser.add_argument("--max-ranges-per-request", type=int)
     parser.add_argument("--file-size", type=int)
     parser.add_argument("--bytes-per-second", type=int)
     parser.add_argument("--chunk-size", type=int)
@@ -673,7 +675,7 @@ def main() -> None:
         f"SDM Fixture listening on {base_url}\n"
         f"  file: {base_url}{EMPTY_FILE_PATH} "
         f"({config.file_size} bytes, {config.bytes_per_second} B/s per connection)\n"
-        f"  max concurrent connections: {config.max_connections}\n"
+        f"  max concurrent transfers: {config.max_concurrent_transfers}\n"
         "  scenarios:\n"
         f"    single connection: {base_url}{SINGLE_CONNECTION_FILE_PATH}\n"
         f"    fails halfway: {base_url}{HALFWAY_FAILURE_FILE_PATH}\n"

--- a/Fixture/tests/test_range_server.py
+++ b/Fixture/tests/test_range_server.py
@@ -13,7 +13,8 @@ from urllib.request import Request, urlopen
 
 from Fixture.range_server import (
     DEFAULT_CONFIG_PATH,
-    DEFAULT_MAX_CONNECTIONS,
+    DEFAULT_MAX_CONCURRENT_TRANSFERS,
+    DEFAULT_MAX_RANGES_PER_REQUEST,
     DYNAMIC_HTML_BODY,
     DYNAMIC_HTML_PATH,
     EMPTY_FILE_PATH,
@@ -70,8 +71,15 @@ class RangeServerTests(unittest.TestCase):
 
     def test_committed_config_matches_runtime_defaults(self) -> None:
         config = FixtureConfig.from_json(DEFAULT_CONFIG_PATH)
-        self.assertEqual(config.max_connections, DEFAULT_MAX_CONNECTIONS)
-        self.assertEqual(config.max_connections, 8)
+        self.assertEqual(
+            config.max_concurrent_transfers,
+            DEFAULT_MAX_CONCURRENT_TRANSFERS,
+        )
+        self.assertEqual(config.max_concurrent_transfers, 8)
+        self.assertEqual(
+            config.max_ranges_per_request,
+            DEFAULT_MAX_RANGES_PER_REQUEST,
+        )
         self.assertEqual(config.file_size, 80 * 1024 * 1024)
         self.assertEqual(config.bytes_per_second, 1024 * 1024)
 
@@ -80,7 +88,7 @@ class RangeServerTests(unittest.TestCase):
         self.assertEqual(response.status, 200)
         self.assertEqual(response.headers["Content-Length"], "8192")
         self.assertEqual(response.headers["Accept-Ranges"], "bytes")
-        self.assertEqual(response.headers["X-SDM-Max-Connections"], "8")
+        self.assertIsNone(response.headers["X-SDM-Max-Connections"])
         self.assertEqual(response.headers["Content-Disposition"], 'attachment; filename="empty.bin"')
         self.assertEqual(response.read(), b"")
 
@@ -120,7 +128,7 @@ class RangeServerTests(unittest.TestCase):
     def test_request_over_range_limit_returns_400(self) -> None:
         config = replace(
             self.config,
-            max_connections=2,
+            max_ranges_per_request=2,
         )
         with running_server(config) as (_, base_url):
             with self.assertRaises(HTTPError) as context:
@@ -171,7 +179,6 @@ class RangeServerTests(unittest.TestCase):
         url = self.base_url + SINGLE_CONNECTION_FILE_PATH
         head = urlopen(Request(url, method="HEAD"), timeout=10)
         self.assertIsNone(head.headers["Accept-Ranges"])
-        self.assertEqual(head.headers["X-SDM-Max-Connections"], "1")
 
         with fetch(url, range_header="bytes=10-19") as response:
             self.assertEqual(response.status, 200)
@@ -184,7 +191,6 @@ class RangeServerTests(unittest.TestCase):
         for _ in range(2):
             with fetch(url) as response:
                 self.assertEqual(response.headers["Content-Length"], "8192")
-                self.assertEqual(response.headers["X-SDM-Max-Connections"], "1")
                 with self.assertRaises(IncompleteRead) as context:
                     response.read()
                 self.assertEqual(
@@ -200,7 +206,6 @@ class RangeServerTests(unittest.TestCase):
             response.headers["X-SDM-Bytes-Per-Second"],
             str(VERY_SLOW_BYTES_PER_SECOND),
         )
-        self.assertEqual(response.headers["X-SDM-Max-Connections"], "1")
         self.assertIsNone(response.headers["Accept-Ranges"])
 
     def test_dynamic_html_has_unknown_length_and_wildcard_range_total(self) -> None:
@@ -265,34 +270,42 @@ class RangeServerTests(unittest.TestCase):
         finally:
             connection.close()
 
-    def test_max_connections_caps_active_range_transfers(self) -> None:
+    def test_excess_range_requests_queue_at_server_transfer_limit(self) -> None:
         config = FixtureConfig(
-            max_connections=2,
-            file_size=160,
-            bytes_per_second=40,
+            max_concurrent_transfers=8,
+            file_size=1_280,
+            bytes_per_second=80,
             chunk_size=10,
         )
 
         with running_server(config) as (server, base_url):
             file_url = base_url + EMPTY_FILE_PATH
-            ranges = [f"bytes={start}-{start + 39}" for start in range(0, 160, 40)]
+            ranges = [
+                f"bytes={start}-{start + 39}"
+                for start in range(0, config.file_size, 40)
+            ]
+            clients_ready = threading.Barrier(len(ranges))
 
             def fetch_body(header: str) -> bytes:
+                clients_ready.wait(timeout=10)
                 with fetch(file_url, range_header=header) as response:
                     return response.read()
 
             started_at = time.monotonic()
-            with ThreadPoolExecutor(max_workers=4) as executor:
+            with ThreadPoolExecutor(max_workers=len(ranges)) as executor:
                 bodies = list(executor.map(fetch_body, ranges))
             elapsed = time.monotonic() - started_at
 
         self.assertEqual(
             bodies,
-            [pattern_bytes(start, 40) for start in range(0, 160, 40)],
+            [
+                pattern_bytes(start, 40)
+                for start in range(0, config.file_size, 40)
+            ],
         )
-        self.assertEqual(server.peak_active_transfers, 2)
+        self.assertEqual(len(ranges), 32)
+        self.assertEqual(server.peak_active_transfers, 8)
         self.assertGreaterEqual(elapsed, 1.7)
-        self.assertLess(elapsed, 4.0)
 
 
 if __name__ == "__main__":

--- a/Packages/SDMCore/Sources/SDMEngine/DownloadStore.cpp
+++ b/Packages/SDMCore/Sources/SDMEngine/DownloadStore.cpp
@@ -96,7 +96,7 @@ public:
             throw std::runtime_error("Unable to read database schema version");
         }
         auto schema_version = sqlite3_column_int(version.get(), 0);
-        if (schema_version > 2) {
+        if (schema_version > 3) {
             throw std::runtime_error("Database schema is newer than this engine");
         }
         if (schema_version == 0) {
@@ -105,6 +105,10 @@ public:
         }
         if (schema_version == 1) {
             migrate_to_version_two();
+            schema_version = 2;
+        }
+        if (schema_version == 2) {
+            migrate_to_version_three();
         }
     }
 
@@ -227,14 +231,29 @@ public:
         }
     }
 
+    void migrate_to_version_three() {
+        execute(database, "BEGIN IMMEDIATE");
+        try {
+            execute(database, R"sql(
+                ALTER TABLE downloads
+                DROP COLUMN server_connection_limit
+            )sql");
+            execute(database, "PRAGMA user_version = 3");
+            execute(database, "COMMIT");
+        } catch (...) {
+            execute(database, "ROLLBACK");
+            throw;
+        }
+    }
+
     std::vector<sdm::PersistedDownload> load_all() {
         Statement downloads(database, R"sql(
             SELECT id, source_url, destination_directory, requested_filename,
                    connection_limit, bandwidth_limit, conflict_policy, final_url,
                    destination_path, filename, state, content_length_known,
                    content_length, downloaded_bytes, error_code, error_message,
-                   temporary_path, accepts_ranges, server_connection_limit,
-                   etag, last_modified, created_milliseconds,
+                   temporary_path, accepts_ranges, etag, last_modified,
+                   created_milliseconds,
                    started_milliseconds, last_attempt_milliseconds,
                    completed_milliseconds, updated_milliseconds
               FROM downloads
@@ -283,25 +302,22 @@ public:
             value.snapshot.error_message = column_text(downloads.get(), 15);
             value.temporary_path = column_text(downloads.get(), 16);
             value.accepts_ranges = sqlite3_column_int(downloads.get(), 17) != 0;
-            value.server_connection_limit = static_cast<std::uint32_t>(
-                sqlite3_column_int64(downloads.get(), 18)
-            );
-            value.etag = column_text(downloads.get(), 19);
-            value.last_modified = column_text(downloads.get(), 20);
+            value.etag = column_text(downloads.get(), 18);
+            value.last_modified = column_text(downloads.get(), 19);
             value.snapshot.created_milliseconds = static_cast<std::uint64_t>(
-                sqlite3_column_int64(downloads.get(), 21)
+                sqlite3_column_int64(downloads.get(), 20)
             );
             value.snapshot.started_milliseconds = static_cast<std::uint64_t>(
-                sqlite3_column_int64(downloads.get(), 22)
+                sqlite3_column_int64(downloads.get(), 21)
             );
             value.snapshot.last_attempt_milliseconds = static_cast<std::uint64_t>(
-                sqlite3_column_int64(downloads.get(), 23)
+                sqlite3_column_int64(downloads.get(), 22)
             );
             value.snapshot.completed_milliseconds = static_cast<std::uint64_t>(
-                sqlite3_column_int64(downloads.get(), 24)
+                sqlite3_column_int64(downloads.get(), 23)
             );
             value.snapshot.updated_milliseconds = static_cast<std::uint64_t>(
-                sqlite3_column_int64(downloads.get(), 25)
+                sqlite3_column_int64(downloads.get(), 24)
             );
             if (has_invalid_state) {
                 value.snapshot.error_code = sdm::Result::persistence_error;
@@ -425,12 +441,12 @@ public:
                     connection_limit, bandwidth_limit, conflict_policy, final_url,
                     destination_path, filename, state, content_length_known,
                     content_length, downloaded_bytes, error_code, error_message,
-                    temporary_path, accepts_ranges, server_connection_limit,
-                    etag, last_modified, created_milliseconds,
+                    temporary_path, accepts_ranges, etag, last_modified,
+                    created_milliseconds,
                     started_milliseconds, last_attempt_milliseconds,
                     completed_milliseconds, updated_milliseconds
                 ) VALUES (
-                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
                     ?, ?, ?, ?, ?
                 )
                 ON CONFLICT(id) DO UPDATE SET
@@ -451,7 +467,6 @@ public:
                     error_message = excluded.error_message,
                     temporary_path = excluded.temporary_path,
                     accepts_ranges = excluded.accepts_ranges,
-                    server_connection_limit = excluded.server_connection_limit,
                     etag = excluded.etag,
                     last_modified = excluded.last_modified,
                     created_milliseconds = excluded.created_milliseconds,
@@ -479,7 +494,6 @@ public:
             bind_text(statement.get(), index++, value.snapshot.error_message);
             bind_text(statement.get(), index++, value.temporary_path);
             sqlite3_bind_int(statement.get(), index++, value.accepts_ranges ? 1 : 0);
-            sqlite3_bind_int64(statement.get(), index++, value.server_connection_limit);
             bind_text(statement.get(), index++, value.etag);
             bind_text(statement.get(), index++, value.last_modified);
             sqlite3_bind_int64(statement.get(), index++, static_cast<sqlite3_int64>(value.snapshot.created_milliseconds));

--- a/Packages/SDMCore/Sources/SDMEngine/DownloadStore.h
+++ b/Packages/SDMCore/Sources/SDMEngine/DownloadStore.h
@@ -14,7 +14,6 @@ struct PersistedDownload final {
     DownloadSnapshot snapshot;
     std::string temporary_path;
     bool accepts_ranges = false;
-    std::uint32_t server_connection_limit = 1;
     std::string etag;
     std::string last_modified;
 };

--- a/Packages/SDMCore/Sources/SDMEngine/Engine.cpp
+++ b/Packages/SDMCore/Sources/SDMEngine/Engine.cpp
@@ -234,7 +234,6 @@ public:
         int file_descriptor = -1;
         std::unordered_set<CURL *> active_handles;
         bool accepts_ranges = false;
-        std::uint32_t server_connection_limit = 1;
         std::vector<Segment> segments;
         std::string etag;
         std::string last_modified;
@@ -575,7 +574,6 @@ private:
                 task->temporary_path = std::move(stored.temporary_path);
                 task->destination_path = task->snapshot.destination_url;
                 task->accepts_ranges = stored.accepts_ranges;
-                task->server_connection_limit = stored.server_connection_limit;
                 task->segments = task->snapshot.segments;
                 task->etag = std::move(stored.etag);
                 task->last_modified = std::move(stored.last_modified);
@@ -894,7 +892,7 @@ private:
         if (task.segments.empty() && task.snapshot.content_length_known &&
             task.snapshot.content_length > 0) {
             const auto connection_limit = task.accepts_ranges
-                ? std::min(task.request.connection_limit, task.server_connection_limit)
+                ? task.request.connection_limit
                 : 1U;
             task.segments = plan_segments(
                 task.snapshot.content_length,
@@ -1156,15 +1154,6 @@ private:
                     std::move(task.snapshot.filename),
                     iterator->second
                 );
-            }
-        }
-        if (const auto iterator = transfer.headers.find("x-sdm-max-connections");
-            iterator != transfer.headers.end()) {
-            if (const auto limit = parse_unsigned(iterator->second); limit && *limit > 0) {
-                task.server_connection_limit = static_cast<std::uint32_t>(std::min<std::uint64_t>(
-                    *limit,
-                    config.maximum_connections_per_download
-                ));
             }
         }
         start_body(task);
@@ -1551,7 +1540,6 @@ private:
                 .snapshot = task.snapshot,
                 .temporary_path = task.temporary_path.string(),
                 .accepts_ranges = task.accepts_ranges,
-                .server_connection_limit = task.server_connection_limit,
                 .etag = task.etag,
                 .last_modified = task.last_modified,
             });

--- a/Packages/SDMCore/Tests/SDMCoreTests/FixtureServer.swift
+++ b/Packages/SDMCore/Tests/SDMCoreTests/FixtureServer.swift
@@ -10,7 +10,7 @@ final class FixtureServer: @unchecked Sendable {
     init(
         fileSize: Int = 64 * 1024,
         bytesPerSecond: Int = 0,
-        maximumConnections: Int = 8
+        maximumConcurrentTransfers: Int = 8
     ) throws {
         let repositoryURL = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
@@ -28,7 +28,7 @@ final class FixtureServer: @unchecked Sendable {
             "--port", "0",
             "--file-size", String(fileSize),
             "--bytes-per-second", String(bytesPerSecond),
-            "--max-connections", String(maximumConnections),
+            "--max-concurrent-transfers", String(maximumConcurrentTransfers),
             "--quiet",
         ]
         process.standardOutput = output

--- a/Packages/SDMCore/Tests/SDMCoreTests/HTTPCompatibilityTests.swift
+++ b/Packages/SDMCore/Tests/SDMCoreTests/HTTPCompatibilityTests.swift
@@ -70,6 +70,7 @@ final class HTTPCompatibilityTests: XCTestCase {
             connections: 2
         )
         XCTAssertEqual(redirected.finalURL?.path, "/empty.bin")
+        XCTAssertEqual(redirected.segments.count, 2)
 
         for snapshot in [fallback, noRange, redirected] {
             let destinationURL = try XCTUnwrap(snapshot.destinationURL)

--- a/Packages/SDMCore/Tests/SDMCoreTests/PersistenceMigrationTests.swift
+++ b/Packages/SDMCore/Tests/SDMCoreTests/PersistenceMigrationTests.swift
@@ -84,7 +84,7 @@ final class PersistenceMigrationTests: XCTestCase {
         }
     }
 
-    func testVersionOneHistoryMigratesInPlaceToVersionTwo() async throws {
+    func testVersionOneHistoryMigratesInPlaceToVersionThree() async throws {
         let root = FileManager.default.temporaryDirectory.appending(
             path: UUID().uuidString,
             directoryHint: .isDirectory
@@ -133,6 +133,6 @@ final class PersistenceMigrationTests: XCTestCase {
         await manager.shutdown()
 
         let version = databaseURL.path.withCString(sdm_test_database_user_version)
-        XCTAssertEqual(version, 2)
+        XCTAssertEqual(version, 3)
     }
 }

--- a/Packages/SDMCore/Tests/SDMCoreTests/PersistenceRecoveryTests.swift
+++ b/Packages/SDMCore/Tests/SDMCoreTests/PersistenceRecoveryTests.swift
@@ -7,7 +7,7 @@ final class PersistenceRecoveryTests: XCTestCase {
         let fixture = try FixtureServer(
             fileSize: 256 * 1024,
             bytesPerSecond: 32 * 1024,
-            maximumConnections: 2
+            maximumConcurrentTransfers: 2
         )
         defer { fixture.stop() }
         let root = FileManager.default.temporaryDirectory.appending(
@@ -54,7 +54,7 @@ final class PersistenceRecoveryTests: XCTestCase {
         let fixture = try FixtureServer(
             fileSize: 32 * 1024,
             bytesPerSecond: 0,
-            maximumConnections: 2
+            maximumConcurrentTransfers: 2
         )
         defer { fixture.stop() }
         let root = FileManager.default.temporaryDirectory.appending(
@@ -95,7 +95,7 @@ final class PersistenceRecoveryTests: XCTestCase {
         let fixture = try FixtureServer(
             fileSize: fileSize,
             bytesPerSecond: 0,
-            maximumConnections: 4
+            maximumConcurrentTransfers: 4
         )
         defer { fixture.stop() }
         let root = FileManager.default.temporaryDirectory
@@ -149,7 +149,7 @@ final class PersistenceRecoveryTests: XCTestCase {
         let fixture = try FixtureServer(
             fileSize: fileSize,
             bytesPerSecond: 64 * 1024,
-            maximumConnections: 4
+            maximumConcurrentTransfers: 4
         )
         defer { fixture.stop() }
         let root = FileManager.default.temporaryDirectory

--- a/Packages/SDMCore/Tests/SDMCoreTests/SegmentedDownloadTests.swift
+++ b/Packages/SDMCore/Tests/SDMCoreTests/SegmentedDownloadTests.swift
@@ -5,7 +5,10 @@ import XCTest
 final class SegmentedDownloadTests: XCTestCase {
     func testTwoFourAndEightConnectionDownloadsAreByteCorrect() async throws {
         let fileSize = 256 * 1024
-        let fixture = try FixtureServer(fileSize: fileSize, maximumConnections: 8)
+        let fixture = try FixtureServer(
+            fileSize: fileSize,
+            maximumConcurrentTransfers: 8
+        )
         defer { fixture.stop() }
         let root = FileManager.default.temporaryDirectory
             .appending(path: UUID().uuidString, directoryHint: .isDirectory)

--- a/README.md
+++ b/README.md
@@ -81,9 +81,10 @@ archive, App packaging, GitHub Release, and post-release development workflow.
 The macOS, iOS, and iPadOS apps embed a Safari Web Extension that sends direct HTTP and HTTPS
 download links to SDM. Run the containing app once, open **Settings > Safari
 Extension**, enable it in Safari, and grant access to the websites where it
-should operate. Links with a `download` attribute and common downloadable file
-extensions are captured automatically. Use **Download with SDM** from Safari's
-link context menu for download endpoints without a recognizable filename.
+should operate. Links with a `download` attribute, common downloadable file
+extensions, and downloadable URLs opened programmatically after a click are
+captured automatically. Use **Download with SDM** from Safari's link context
+menu for download endpoints without a recognizable filename.
 
 Holding a modifier key while clicking bypasses SDM and preserves Safari's
 normal link handling. This first version forwards direct GET URLs and suggested

--- a/SafariExtension/Resources/content.js
+++ b/SafariExtension/Resources/content.js
@@ -1,5 +1,8 @@
 (() => {
+  const extensionAPI = globalThis.browser ?? globalThis.chrome;
   const callbackScheme = "swifty-download-manager";
+  const pageBridgeSource = "swifty-download-manager-page-bridge";
+  const pageBridgeToken = globalThis.crypto.randomUUID();
   const downloadableExtensions = new Set([
     "7z", "aac", "apk", "app", "arc", "arj", "avi", "bin", "bz2", "cab",
     "csv", "dmg", "doc", "docx", "epub", "exe", "flac", "gz", "img", "iso",
@@ -34,7 +37,11 @@
   }
 
   function isDownloadLink(link, url) {
-    return link.hasAttribute("download") || downloadableExtensions.has(inferredExtension(url));
+    return link.hasAttribute("download") || isDownloadURL(url);
+  }
+
+  function isDownloadURL(url) {
+    return downloadableExtensions.has(inferredExtension(url));
   }
 
   function suggestedFilename(link) {
@@ -54,6 +61,66 @@
     }
     return url.href;
   }
+
+  function postPageBridgeResponse(id, accepted) {
+    window.postMessage({
+      source: pageBridgeSource,
+      token: pageBridgeToken,
+      type: "downloadResponse",
+      id,
+      accepted,
+    }, window.location.origin);
+  }
+
+  function postPageBridgeInitialization() {
+    window.postMessage({
+      source: pageBridgeSource,
+      token: pageBridgeToken,
+      type: "bridgeInitialize",
+    }, window.location.origin);
+  }
+
+  window.addEventListener("message", (event) => {
+    const message = event.data;
+    if (
+      event.source !== window ||
+      event.origin !== window.location.origin ||
+      message?.source !== pageBridgeSource
+    ) {
+      return;
+    }
+
+    if (message.type === "bridgeReady") {
+      postPageBridgeInitialization();
+      return;
+    }
+
+    if (
+      message.token !== pageBridgeToken ||
+      message.type !== "downloadRequest" ||
+      typeof message.id !== "string"
+    ) {
+      return;
+    }
+
+    const url = parsedHTTPURL(message.url);
+    if (!url || !isDownloadURL(url)) {
+      postPageBridgeResponse(message.id, false);
+      return;
+    }
+
+    void extensionAPI.runtime.sendMessage({
+      type: "captureDownload",
+      url: url.href,
+      sourcePage: window.location.href,
+    }).then((response) => {
+      postPageBridgeResponse(message.id, response?.accepted === true);
+    }).catch(() => {
+      postPageBridgeResponse(message.id, false);
+    });
+  });
+
+  postPageBridgeInitialization();
 
   document.addEventListener("click", (event) => {
     if (

--- a/SafariExtension/Resources/manifest.json
+++ b/SafariExtension/Resources/manifest.json
@@ -30,6 +30,18 @@
       ],
       "run_at": "document_start",
       "all_frames": true
+    },
+    {
+      "matches": [
+        "http://*/*",
+        "https://*/*"
+      ],
+      "js": [
+        "page.js"
+      ],
+      "run_at": "document_start",
+      "all_frames": true,
+      "world": "MAIN"
     }
   ],
   "permissions": [

--- a/SafariExtension/Resources/page.js
+++ b/SafariExtension/Resources/page.js
@@ -1,0 +1,125 @@
+(() => {
+  const pageBridgeSource = "swifty-download-manager-page-bridge";
+  const userGestureLifetimeMilliseconds = 30_000;
+  const responseTimeoutMilliseconds = 5_000;
+  const downloadableExtensions = new Set([
+    "7z", "aac", "apk", "app", "arc", "arj", "avi", "bin", "bz2", "cab",
+    "csv", "dmg", "doc", "docx", "epub", "exe", "flac", "gz", "img", "iso",
+    "jar", "key", "m4a", "m4v", "mkv", "mov", "mp3", "mp4", "mpeg", "mpg",
+    "msi", "numbers", "odf", "ods", "odt", "pages", "pdf", "pkg", "ppt",
+    "pptx", "rar", "rtf", "tar", "tgz", "tif", "tiff", "ts", "txt", "wav",
+    "webm", "wma", "wmv", "xls", "xlsx", "xip", "xz", "zip", "zipx"
+  ]);
+
+  if (window.__sdmPageBridgeInstalled === true) {
+    return;
+  }
+  window.__sdmPageBridgeInstalled = true;
+
+  const originalWindowOpen = window.open.bind(window);
+  const pendingDownloads = new Map();
+  let bridgeToken;
+  let lastEligibleClickMilliseconds = 0;
+  let requestOrdinal = 0;
+
+  function parsedDownloadURL(value) {
+    try {
+      const url = new URL(String(value), document.baseURI);
+      if (url.protocol !== "http:" && url.protocol !== "https:") {
+        return null;
+      }
+      const name = url.pathname.split("/").pop() ?? "";
+      const separator = name.lastIndexOf(".");
+      const extension = separator >= 0 ? name.slice(separator + 1).toLowerCase() : "";
+      return downloadableExtensions.has(extension) ? url : null;
+    } catch {
+      return null;
+    }
+  }
+
+  function hasRecentEligibleClick() {
+    return Date.now() - lastEligibleClickMilliseconds <= userGestureLifetimeMilliseconds;
+  }
+
+  function resumeDownload(request) {
+    originalWindowOpen(...request.arguments);
+  }
+
+  function finishRequest(id, accepted) {
+    const request = pendingDownloads.get(id);
+    if (!request) {
+      return;
+    }
+    pendingDownloads.delete(id);
+    window.clearTimeout(request.timeout);
+    if (!accepted) {
+      resumeDownload(request);
+    }
+  }
+
+  document.addEventListener("click", (event) => {
+    if (
+      event.isTrusted &&
+      event.button === 0 &&
+      !event.altKey &&
+      !event.ctrlKey &&
+      !event.metaKey &&
+      !event.shiftKey
+    ) {
+      lastEligibleClickMilliseconds = Date.now();
+    }
+  }, true);
+
+  window.addEventListener("message", (event) => {
+    const message = event.data;
+    if (
+      event.source !== window ||
+      event.origin !== window.location.origin ||
+      message?.source !== pageBridgeSource
+    ) {
+      return;
+    }
+
+    if (message.type === "bridgeInitialize" && typeof message.token === "string") {
+      bridgeToken = message.token;
+      return;
+    }
+
+    if (
+      !bridgeToken ||
+      message.token !== bridgeToken ||
+      message.type !== "downloadResponse" ||
+      typeof message.id !== "string"
+    ) {
+      return;
+    }
+    finishRequest(message.id, message.accepted === true);
+  });
+
+  window.open = function (...args) {
+    const url = parsedDownloadURL(args[0]);
+    if (!bridgeToken || !url || !hasRecentEligibleClick()) {
+      return originalWindowOpen(...args);
+    }
+
+    const id = `${Date.now()}-${requestOrdinal++}`;
+    const request = {
+      arguments: [url.href, ...args.slice(1)],
+      timeout: window.setTimeout(() => finishRequest(id, false), responseTimeoutMilliseconds),
+    };
+    pendingDownloads.set(id, request);
+    window.postMessage({
+      source: pageBridgeSource,
+      token: bridgeToken,
+      type: "downloadRequest",
+      id,
+      url: url.href,
+    }, window.location.origin);
+    return null;
+  };
+
+  window.postMessage({
+    source: pageBridgeSource,
+    type: "bridgeReady",
+  }, window.location.origin);
+})();

--- a/SafariExtension/Sources/SafariWebExtensionHandler.swift
+++ b/SafariExtension/Sources/SafariWebExtensionHandler.swift
@@ -1,7 +1,17 @@
+#if os(macOS)
+import AppKit
+#endif
 import SafariServices
 
 final class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling, @unchecked Sendable {
     private static let callbackScheme = "swifty-download-manager"
+    #if os(macOS)
+    private static let containingApplicationIdentifier =
+        "top.kyleye.swifty-download-manager-app"
+    private static let callbackNotificationName = Notification.Name(
+        "top.kyleye.swifty-download-manager.browser-callback"
+    )
+    #endif
 
     func beginRequest(with context: NSExtensionContext) {
         guard let item = context.inputItems.first as? NSExtensionItem,
@@ -61,6 +71,21 @@ final class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling, @un
             reply(to: context, accepted: false, error: "The app callback URL could not be created.")
             return
         }
+
+        #if os(macOS)
+        if !NSRunningApplication.runningApplications(
+            withBundleIdentifier: Self.containingApplicationIdentifier
+        ).isEmpty {
+            DistributedNotificationCenter.default().postNotificationName(
+                Self.callbackNotificationName,
+                object: callbackURL.absoluteString,
+                userInfo: nil,
+                deliverImmediately: true
+            )
+            reply(to: context, accepted: true, error: nil)
+            return
+        }
+        #endif
 
         let contextBox = ExtensionContextBox(context)
         context.open(callbackURL) { [weak self, contextBox] accepted in

--- a/SafariExtension/Tests/DownloadInterceptionTests.js
+++ b/SafariExtension/Tests/DownloadInterceptionTests.js
@@ -1,0 +1,272 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+
+const resourcesDirectory = path.join(__dirname, "..", "Resources");
+const contentSource = fs.readFileSync(path.join(resourcesDirectory, "content.js"), "utf8");
+const pageSource = fs.readFileSync(path.join(resourcesDirectory, "page.js"), "utf8");
+const bridgeSource = "swifty-download-manager-page-bridge";
+const pageOrigin = "https://www.trae.cn";
+
+class FakeEventTarget {
+  constructor() {
+    this.listeners = new Map();
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type, event) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener.call(this, event);
+    }
+  }
+}
+
+function pageBridgeHarness() {
+  const originalOpenCalls = [];
+  const postedMessages = [];
+  const timeouts = new Map();
+  const document = new FakeEventTarget();
+  const window = new FakeEventTarget();
+  let nextTimeout = 1;
+
+  document.baseURI = `${pageOrigin}/`;
+  window.location = { origin: pageOrigin };
+  window.open = (...args) => {
+    originalOpenCalls.push(args);
+    return { opened: true };
+  };
+  window.postMessage = (message, targetOrigin) => {
+    postedMessages.push({ message, targetOrigin });
+  };
+  window.setTimeout = (callback) => {
+    const identifier = nextTimeout++;
+    timeouts.set(identifier, callback);
+    return identifier;
+  };
+  window.clearTimeout = (identifier) => {
+    timeouts.delete(identifier);
+  };
+
+  vm.runInNewContext(pageSource, {
+    Date,
+    Map,
+    Set,
+    String,
+    URL,
+    document,
+    window,
+  });
+
+  window.dispatch("message", {
+    data: {
+      source: bridgeSource,
+      token: "test-token",
+      type: "bridgeInitialize",
+    },
+    origin: pageOrigin,
+    source: window,
+  });
+  postedMessages.length = 0;
+
+  return {
+    document,
+    originalOpenCalls,
+    postedMessages,
+    timeouts,
+    window,
+  };
+}
+
+function dispatchEligibleClick(document) {
+  document.dispatch("click", {
+    altKey: false,
+    button: 0,
+    ctrlKey: false,
+    isTrusted: true,
+    metaKey: false,
+    shiftKey: false,
+  });
+}
+
+function replyToPageBridge(harness, request, accepted) {
+  harness.window.dispatch("message", {
+    data: {
+      source: bridgeSource,
+      token: "test-token",
+      type: "downloadResponse",
+      id: request.message.id,
+      accepted,
+    },
+    origin: pageOrigin,
+    source: harness.window,
+  });
+}
+
+test("programmatic download is captured after a real click", () => {
+  const harness = pageBridgeHarness();
+  dispatchEligibleClick(harness.document);
+
+  const result = harness.window.open(
+    "https://cdn.example.com/TRAE_Work_CN-darwin-arm64.dmg",
+    "_self"
+  );
+
+  assert.equal(result, null);
+  assert.equal(harness.originalOpenCalls.length, 0);
+  assert.equal(harness.postedMessages.length, 1);
+  assert.equal(harness.postedMessages[0].message.type, "downloadRequest");
+  assert.equal(
+    harness.postedMessages[0].message.url,
+    "https://cdn.example.com/TRAE_Work_CN-darwin-arm64.dmg"
+  );
+
+  replyToPageBridge(harness, harness.postedMessages[0], true);
+  assert.equal(harness.originalOpenCalls.length, 0);
+  assert.equal(harness.timeouts.size, 0);
+});
+
+test("rejected programmatic download resumes the original window.open", () => {
+  const harness = pageBridgeHarness();
+  dispatchEligibleClick(harness.document);
+  harness.window.open("https://cdn.example.com/file.dmg", "_self", "noopener");
+
+  replyToPageBridge(harness, harness.postedMessages[0], false);
+
+  assert.deepEqual(harness.originalOpenCalls, [[
+    "https://cdn.example.com/file.dmg",
+    "_self",
+    "noopener",
+  ]]);
+  assert.equal(harness.timeouts.size, 0);
+});
+
+test("unanswered programmatic download resumes after the bridge timeout", () => {
+  const harness = pageBridgeHarness();
+  dispatchEligibleClick(harness.document);
+  harness.window.open("https://cdn.example.com/file.dmg", "_self");
+
+  const timeout = [...harness.timeouts.values()][0];
+  timeout();
+
+  assert.deepEqual(harness.originalOpenCalls, [[
+    "https://cdn.example.com/file.dmg",
+    "_self",
+  ]]);
+});
+
+test("ordinary navigation and downloads without a click are not captured", () => {
+  const harness = pageBridgeHarness();
+
+  harness.window.open("https://example.com/page", "_self");
+  harness.window.open("https://cdn.example.com/file.dmg", "_self");
+
+  assert.equal(harness.postedMessages.length, 0);
+  assert.equal(harness.originalOpenCalls.length, 2);
+});
+
+function contentBridgeHarness() {
+  const runtimeMessages = [];
+  const postedMessages = [];
+  const document = new FakeEventTarget();
+  const window = new FakeEventTarget();
+
+  document.baseURI = `${pageOrigin}/`;
+  window.location = {
+    href: `${pageOrigin}/`,
+    origin: pageOrigin,
+  };
+  window.postMessage = (message, targetOrigin) => {
+    postedMessages.push({ message, targetOrigin });
+  };
+
+  class HTMLAnchorElement {}
+  class HTMLAreaElement {}
+  const browser = {
+    runtime: {
+      sendMessage(message) {
+        runtimeMessages.push(message);
+        return Promise.resolve({ accepted: true });
+      },
+    },
+  };
+
+  vm.runInNewContext(contentSource, {
+    HTMLAnchorElement,
+    HTMLAreaElement,
+    Promise,
+    Set,
+    URL,
+    browser,
+    crypto: { randomUUID: () => "test-token" },
+    document,
+    window,
+  });
+
+  return {
+    postedMessages,
+    runtimeMessages,
+    window,
+  };
+}
+
+test("content bridge forwards a page download request to the extension", async () => {
+  const harness = contentBridgeHarness();
+  assert.equal(harness.postedMessages[0].message.type, "bridgeInitialize");
+  harness.postedMessages.length = 0;
+
+  harness.window.dispatch("message", {
+    data: {
+      source: bridgeSource,
+      token: "test-token",
+      type: "downloadRequest",
+      id: "request-1",
+      url: "https://cdn.example.com/file.dmg",
+    },
+    origin: pageOrigin,
+    source: harness.window,
+  });
+  await Promise.resolve();
+
+  assert.equal(harness.runtimeMessages.length, 1);
+  assert.equal(harness.runtimeMessages[0].type, "captureDownload");
+  assert.equal(harness.runtimeMessages[0].url, "https://cdn.example.com/file.dmg");
+  assert.equal(harness.runtimeMessages[0].sourcePage, `${pageOrigin}/`);
+  assert.equal(harness.postedMessages[0].message.type, "downloadResponse");
+  assert.equal(harness.postedMessages[0].message.accepted, true);
+});
+
+test("content bridge rejects unrecognized download URLs", () => {
+  const harness = contentBridgeHarness();
+  harness.postedMessages.length = 0;
+
+  harness.window.dispatch("message", {
+    data: {
+      source: bridgeSource,
+      token: "test-token",
+      type: "downloadRequest",
+      id: "request-2",
+      url: "https://example.com/page",
+    },
+    origin: pageOrigin,
+    source: harness.window,
+  });
+
+  assert.equal(harness.runtimeMessages.length, 0);
+  assert.equal(harness.postedMessages[0].message.accepted, false);
+});
+
+test("page bridge runs as a main-world content script", () => {
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(resourcesDirectory, "manifest.json"), "utf8")
+  );
+  assert.ok(manifest.content_scripts.some((contentScript) =>
+    contentScript.world === "MAIN" && contentScript.js.includes("page.js")
+  ));
+});

--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -5,5 +5,6 @@ set -euo pipefail
 SDM_REPOSITORY_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$SDM_REPOSITORY_DIR"
 
+node --test SafariExtension/Tests/DownloadInterceptionTests.js
 python3 -m unittest discover -s Fixture/tests -v
 swift test --package-path Packages/SDMCore


### PR DESCRIPTION
## Summary

- Honor the standard `Accept-Ranges: bytes` signal when deciding whether a download can be segmented.
- Remove the private `X-SDM-Max-Connections` fixture contract and model server capacity with independent concurrent-transfer and multi-range limits.
- Capture downloadable URLs opened through page-level `window.open` after a trusted click, while preserving normal navigation and falling back to Safari if SDM rejects the request.
- Use a tokenized main-world/content-script bridge, native messaging, and a macOS running-app notification path while preserving the iOS callback flow from `main`.

## Root cause

The segmented downloader depended on a private response header instead of the HTTP range capability signal. Separately, the TraeWork download button opens the DMG programmatically rather than through an anchor element, so the existing click interceptor never observed it.

## Validation

- `bash Scripts/test.sh`: 7 Safari JavaScript tests, 19 Fixture tests, and 30 Swift tests passed.
- macOS Debug app build passed.
- iOS Simulator Debug app build passed.
- Live Safari validation with a temporary `0.2.2` build: Safari stayed on the Trae page and SDM received a new `lf-cdn.trae.com.cn` download task.