### PR TITLE
Optimize Settings UI for iOS

### DIFF
--- a/App/Sources/DownloadEngineFeaturesView.swift
+++ b/App/Sources/DownloadEngineFeaturesView.swift
@@ -1,0 +1,41 @@
+#if os(iOS)
+import SDMCore
+import SwiftUI
+
+struct DownloadEngineFeaturesView: View {
+    let descriptor: DownloadEngineDescriptor
+
+    var body: some View {
+        List {
+            Section("Selected Engine") {
+                LabeledContent("Engine", value: descriptor.kind.title)
+                LabeledContent("Version", value: descriptor.version)
+            }
+
+            Section("Capabilities") {
+                ForEach(DownloadFeature.allCases) { feature in
+                    Label {
+                        Text(feature.title)
+                    } icon: {
+                        Image(
+                            systemName: descriptor.supports(feature)
+                                ? "checkmark.circle.fill"
+                                : "xmark.circle"
+                        )
+                        .foregroundStyle(
+                            descriptor.supports(feature) ? Color.green : Color.secondary
+                        )
+                    }
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel(feature.title)
+                    .accessibilityValue(
+                        descriptor.supports(feature) ? "Supported" : "Not supported"
+                    )
+                }
+            }
+        }
+        .navigationTitle("Engine Capabilities")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+#endif

--- a/App/Sources/DownloadEngineInformationView.swift
+++ b/App/Sources/DownloadEngineInformationView.swift
@@ -1,0 +1,37 @@
+#if os(iOS)
+import SDMCore
+import SwiftUI
+
+struct DownloadEngineInformationView: View {
+    let descriptor: DownloadEngineDescriptor
+    let databaseURL: URL?
+
+    var body: some View {
+        Form {
+            Section("Engine") {
+                LabeledContent("Selected", value: descriptor.kind.title)
+                LabeledContent("Version", value: descriptor.version)
+                LabeledContent("Runtime", value: SDMCoreInfo.engineVersion)
+                LabeledContent("libcurl", value: SDMCoreInfo.libcurlVersion)
+                LabeledContent("ABI") {
+                    Text(SDMCoreInfo.engineABIVersion, format: .number)
+                }
+            }
+
+            if let databaseURL {
+                Section("Storage") {
+                    LabeledContent("History database") {
+                        Text(databaseURL.path(percentEncoded: false))
+                            .lineLimit(3)
+                            .truncationMode(.middle)
+                            .multilineTextAlignment(.trailing)
+                            .textSelection(.enabled)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Engine Information")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+#endif

--- a/App/Sources/MacSettingsFormContent.swift
+++ b/App/Sources/MacSettingsFormContent.swift
@@ -1,0 +1,114 @@
+#if os(macOS)
+import SDMCore
+import SwiftUI
+
+struct MacSettingsFormContent: View {
+    @Binding var defaultConnectionCount: Int
+    @Binding var showsMenuBarIcon: Bool
+    @Binding var selectedEngine: String
+    let engineDescriptors: [DownloadEngineDescriptor]
+    let selectedDescriptor: DownloadEngineDescriptor?
+    let safariExtensionIsEnabled: Bool?
+    let databaseURL: URL?
+    let openSafariSettings: () -> Void
+    let showLegalNotices: () -> Void
+
+    var body: some View {
+        Section("General") {
+            Picker("Application icon location", selection: $showsMenuBarIcon) {
+                Text("In Dock and Menu Bar")
+                    .tag(true)
+                Text("In Dock only")
+                    .tag(false)
+            }
+            .pickerStyle(.menu)
+
+            Picker("Download engine", selection: $selectedEngine) {
+                ForEach(engineDescriptors) { descriptor in
+                    Text(descriptor.kind.title)
+                        .tag(descriptor.kind.rawValue)
+                }
+            }
+            .pickerStyle(.menu)
+
+            if let selectedDescriptor {
+                ForEach(DownloadFeature.allCases) { feature in
+                    Label(
+                        feature.title,
+                        systemImage: selectedDescriptor.supports(feature)
+                            ? "checkmark.circle.fill"
+                            : "xmark.circle"
+                    )
+                    .foregroundStyle(
+                        selectedDescriptor.supports(feature) ? .primary : .secondary
+                    )
+                }
+            }
+        }
+
+        Section {
+            Stepper(
+                "Default connections: \(defaultConnectionCount)",
+                value: $defaultConnectionCount,
+                in: 1 ... 16
+            )
+            .disabled(selectedDescriptor?.supports(.multiConnectionTransfers) == false)
+        } header: {
+            Text("Downloads")
+        } footer: {
+            if selectedDescriptor?.supports(.multiConnectionTransfers) == false {
+                Text("URLSession manages connections internally and uses one connection per download.")
+            }
+        }
+
+        Section("Safari Extension") {
+            LabeledContent("Status") {
+                Text(extensionStatusTitle)
+                    .foregroundStyle(extensionStatusStyle)
+            }
+
+            Text("Enable the extension in Safari, then allow website access. Download links and the Download with SDM context menu will send supported HTTP and HTTPS files to SDM.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
+            Button("Open Safari Extension Settings", action: openSafariSettings)
+        }
+
+        Section("Engine") {
+            LabeledContent("Version", value: SDMCoreInfo.engineVersion)
+            LabeledContent("libcurl", value: SDMCoreInfo.libcurlVersion)
+            LabeledContent("ABI") {
+                Text(SDMCoreInfo.engineABIVersion, format: .number)
+            }
+            if let databaseURL {
+                LabeledContent("History database") {
+                    Text(databaseURL.path(percentEncoded: false))
+                        .lineLimit(2)
+                        .truncationMode(.middle)
+                        .textSelection(.enabled)
+                }
+            }
+        }
+
+        Section("Legal") {
+            Text("libcurl, curl-apple, OpenSSL, and Mozilla license texts are included with the app.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
+            Button("View Third-Party Licenses", action: showLegalNotices)
+        }
+    }
+
+    private var extensionStatusTitle: String {
+        switch safariExtensionIsEnabled {
+        case true: "Enabled"
+        case false: "Disabled"
+        case nil: "Checking…"
+        }
+    }
+
+    private var extensionStatusStyle: Color {
+        safariExtensionIsEnabled == true ? .green : .secondary
+    }
+}
+#endif

--- a/App/Sources/MobileSettingsFormContent.swift
+++ b/App/Sources/MobileSettingsFormContent.swift
@@ -1,0 +1,102 @@
+#if os(iOS)
+import SDMCore
+import SwiftUI
+
+struct MobileSettingsFormContent: View {
+    @Binding var defaultConnectionCount: Int
+    @Binding var selectedEngine: String
+    let engineDescriptors: [DownloadEngineDescriptor]
+    let selectedDescriptor: DownloadEngineDescriptor?
+    let safariExtensionIsEnabled: Bool?
+    let databaseURL: URL?
+    let openSafariSettings: () -> Void
+
+    var body: some View {
+        Section("General") {
+            Picker("Download engine", selection: $selectedEngine) {
+                ForEach(engineDescriptors) { descriptor in
+                    Text(descriptor.kind.title)
+                        .tag(descriptor.kind.rawValue)
+                }
+            }
+            .pickerStyle(.navigationLink)
+
+            if let selectedDescriptor {
+                NavigationLink {
+                    DownloadEngineFeaturesView(descriptor: selectedDescriptor)
+                } label: {
+                    Label("Engine Capabilities", systemImage: "gearshape.2")
+                }
+            }
+        }
+
+        Section {
+            Stepper(value: $defaultConnectionCount, in: 1 ... 16) {
+                LabeledContent("Default connections") {
+                    Text(defaultConnectionCount, format: .number)
+                }
+            }
+            .disabled(selectedDescriptor?.supports(.multiConnectionTransfers) == false)
+        } header: {
+            Text("Downloads")
+        } footer: {
+            if selectedDescriptor?.supports(.multiConnectionTransfers) == false {
+                Text("URLSession manages connections internally and uses one connection per download.")
+            } else {
+                Text("New downloads use this many connections when the server supports segmented transfers.")
+            }
+        }
+
+        Section {
+            LabeledContent("Status") {
+                Text(extensionStatusTitle)
+                    .foregroundStyle(extensionStatusStyle)
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Status")
+            .accessibilityValue(extensionStatusTitle)
+
+            Button(
+                "Open Safari Settings",
+                systemImage: "safari",
+                action: openSafariSettings
+            )
+        } header: {
+            Text("Safari Extension")
+        } footer: {
+            Text("Enable the extension, then allow website access for all websites to send supported downloads to SDM.")
+        }
+
+        Section("About") {
+            if let selectedDescriptor {
+                NavigationLink {
+                    DownloadEngineInformationView(
+                        descriptor: selectedDescriptor,
+                        databaseURL: databaseURL
+                    )
+                } label: {
+                    Label("Engine Information", systemImage: "info.circle")
+                }
+            }
+
+            NavigationLink {
+                LegalNoticesView()
+            } label: {
+                Label("Third-Party Licenses", systemImage: "doc.text")
+            }
+        }
+    }
+
+    private var extensionStatusTitle: String {
+        switch safariExtensionIsEnabled {
+        case true: "Enabled"
+        case false: "Disabled"
+        case nil: "Manage in Settings"
+        }
+    }
+
+    private var extensionStatusStyle: Color {
+        safariExtensionIsEnabled == true ? .green : .secondary
+    }
+}
+#endif

--- a/App/Sources/SettingsView.swift
+++ b/App/Sources/SettingsView.swift
@@ -3,112 +3,48 @@ import SwiftUI
 
 struct SettingsView: View {
     @AppStorage(AppStorageKey.defaultConnectionCount) private var defaultConnectionCount = 8
-    @AppStorage(AppStorageKey.showsMenuBarIcon) private var showsMenuBarIcon = true
     @AppStorage(AppStorageKey.downloadEngine) private var selectedEngine = DownloadEngineKind.libcurl.rawValue
+    #if os(macOS)
+    @AppStorage(AppStorageKey.showsMenuBarIcon) private var showsMenuBarIcon = true
+    #endif
     @State private var safariExtensionIsEnabled: Bool?
     @State private var presentedError: PresentedDownloadError?
+    #if os(macOS)
     @State private var showsLegalNotices = false
+    #endif
     @Bindable var service: DownloadService
 
     var body: some View {
         Form {
-            Section("General") {
-                #if os(macOS)
-                Picker("Application icon location", selection: $showsMenuBarIcon) {
-                    Text("In Dock and Menu Bar")
-                        .tag(true)
-                    Text("In Dock only")
-                        .tag(false)
-                }
-                .pickerStyle(.menu)
-                #endif
-
-                Picker("Download engine", selection: $selectedEngine) {
-                    ForEach(service.engineDescriptors) { descriptor in
-                        Text(descriptor.kind.title)
-                            .tag(descriptor.kind.rawValue)
-                    }
-                }
-                .pickerStyle(.menu)
-
-                if let descriptor = selectedDescriptor {
-                    ForEach(DownloadFeature.allCases) { feature in
-                        Label(
-                            feature.title,
-                            systemImage: descriptor.supports(feature)
-                                ? "checkmark.circle.fill"
-                                : "xmark.circle"
-                        )
-                        .foregroundStyle(
-                            descriptor.supports(feature) ? .primary : .secondary
-                        )
-                    }
-                }
-            }
-
-            Section {
-                Stepper(
-                    "Default connections: \(defaultConnectionCount)",
-                    value: $defaultConnectionCount,
-                    in: 1 ... 16
-                )
-                .disabled(selectedDescriptor?.supports(.multiConnectionTransfers) == false)
-            } header: {
-                Text("Downloads")
-            } footer: {
-                if selectedDescriptor?.supports(.multiConnectionTransfers) == false {
-                    Text("URLSession manages connections internally and uses one connection per download.")
-                }
-            }
-
-            Section("Safari Extension") {
-                LabeledContent("Status") {
-                    Text(extensionStatusTitle)
-                        .foregroundStyle(extensionStatusColor)
-                }
-
-                #if os(macOS)
-                Text("Enable the extension in Safari, then allow website access. Download links and the Download with SDM context menu will send supported HTTP and HTTPS files to SDM.")
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-                #else
-                Text("Enable the extension in Safari, then set Website Access to Allow on All Websites. Supported HTTP and HTTPS download links will open in SDM.")
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-                #endif
-
-                Button("Open Safari Extension Settings") {
-                    SafariExtensionSupport.showPreferences()
-                }
-            }
-
-            Section("Engine") {
-                LabeledContent("Version", value: SDMCoreInfo.engineVersion)
-                LabeledContent("libcurl", value: SDMCoreInfo.libcurlVersion)
-                LabeledContent("ABI", value: String(SDMCoreInfo.engineABIVersion))
-                if let databaseURL = service.databaseURL {
-                    LabeledContent("History database") {
-                        Text(databaseURL.path(percentEncoded: false))
-                            .lineLimit(2)
-                            .truncationMode(.middle)
-                            .textSelection(.enabled)
-                    }
-                }
-            }
-
-            Section("Legal") {
-                Text("libcurl, curl-apple, OpenSSL, and Mozilla license texts are included with the app.")
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-
-                Button("View Third-Party Licenses") {
-                    showsLegalNotices = true
-                }
-            }
+            #if os(iOS)
+            MobileSettingsFormContent(
+                defaultConnectionCount: $defaultConnectionCount,
+                selectedEngine: $selectedEngine,
+                engineDescriptors: service.engineDescriptors,
+                selectedDescriptor: selectedDescriptor,
+                safariExtensionIsEnabled: safariExtensionIsEnabled,
+                databaseURL: service.databaseURL,
+                openSafariSettings: SafariExtensionSupport.showPreferences
+            )
+            #else
+            MacSettingsFormContent(
+                defaultConnectionCount: $defaultConnectionCount,
+                showsMenuBarIcon: $showsMenuBarIcon,
+                selectedEngine: $selectedEngine,
+                engineDescriptors: service.engineDescriptors,
+                selectedDescriptor: selectedDescriptor,
+                safariExtensionIsEnabled: safariExtensionIsEnabled,
+                databaseURL: service.databaseURL,
+                openSafariSettings: SafariExtensionSupport.showPreferences,
+                showLegalNotices: { showsLegalNotices = true }
+            )
+            #endif
         }
         .formStyle(.grouped)
+        #if os(iOS)
+        .scrollContentBackground(.visible)
+        #else
         .padding()
-        #if os(macOS)
         .frame(width: 560, height: 620)
         #endif
         .task {
@@ -137,6 +73,7 @@ struct SettingsView: View {
                 dismissButton: .default(Text("OK"))
             )
         }
+        #if os(macOS)
         .sheet(isPresented: $showsLegalNotices) {
             NavigationStack {
                 LegalNoticesView()
@@ -149,26 +86,7 @@ struct SettingsView: View {
                     }
             }
         }
-    }
-
-    private var extensionStatusTitle: String {
-        switch safariExtensionIsEnabled {
-        case true: "Enabled"
-        case false: "Disabled"
-        #if os(macOS)
-        case nil: "Checking…"
-        #else
-        case nil: "Manage in Settings"
         #endif
-        }
-    }
-
-    private var extensionStatusColor: Color {
-        switch safariExtensionIsEnabled {
-        case true: .green
-        case false: .secondary
-        case nil: .secondary
-        }
     }
 
     private var selectedDescriptor: DownloadEngineDescriptor? {
@@ -198,5 +116,8 @@ struct SettingsView: View {
 }
 
 #Preview {
-    SettingsView(service: .preview())
+    NavigationStack {
+        SettingsView(service: .preview())
+            .navigationTitle("Settings")
+    }
 }


### PR DESCRIPTION
## Summary

- split Settings form content into dedicated iOS and macOS views
- adopt native iOS navigation and grouped form presentation
- move engine capabilities and engine information into drill-in screens
- refine Downloads, Safari Extension, and About sections for compact native spacing
- preserve the existing macOS Settings experience

## Why

The shared cross-platform Settings layout produced oversized rows, inconsistent separators, and awkward spacing on iOS. Platform-specific content lets SwiftUI apply native iOS form sizing and navigation while keeping macOS behavior stable.

## Impact

iOS Settings now uses standard grouped rows, native separators, accessible status values, and clearer information hierarchy. The Safari Extension status/action rows have consistent spacing and VoiceOver exposes the status value correctly.

## Validation

- ✅ iOS Simulator build: `xcodebuild build ... platform=iOS Simulator`
- ✅ macOS build: `xcodebuild build ... platform=macOS`
- ✅ visually checked on iPhone 17 Pro simulator, iOS 26.5
- ⚠️ `swift test --package-path Packages/SDMCore`: 29/30 tests pass; `DownloadManagerLifecycleTests.testManagerRejectsInvalidConnectionLimit` fails while creating the engine with persistence error code 7. This PR does not modify `Packages/SDMCore`, and the failure reproduced on an isolated rerun.
