### PR TITLE
Fix HTTPS certificate trust loading

### DIFF
--- a/Packages/SDMCore/Package.swift
+++ b/Packages/SDMCore/Package.swift
@@ -61,7 +61,10 @@ let package = Package(
         ),
         .target(
             name: "SDMEngineTestSupport",
-            dependencies: ["SDMEngine"],
+            dependencies: [
+                "SDMEngine",
+                .product(name: "CurlBinary", package: "CurlBinary"),
+            ],
             path: "Tests/SDMEngineTestSupport",
             publicHeadersPath: "include"
         ),

--- a/Packages/SDMCore/Sources/SDMCore/Backends/Curl/CertificateAuthorityBundle.swift
+++ b/Packages/SDMCore/Sources/SDMCore/Backends/Curl/CertificateAuthorityBundle.swift
@@ -18,7 +18,7 @@ enum CertificateAuthorityBundle {
         let bundle = certificates.map { certificate in
             let data = SecCertificateCopyData(certificate) as Data
             let body = data.base64EncodedString(options: [.lineLength64Characters, .endLineWithLineFeed])
-            return "-----BEGIN CERTIFICATE-----\n\(body)-----END CERTIFICATE-----\n"
+            return "-----BEGIN CERTIFICATE-----\n\(body)\n-----END CERTIFICATE-----\n"
         }
         .joined()
 

--- a/Packages/SDMCore/Sources/SDMEngine/Engine.cpp
+++ b/Packages/SDMCore/Sources/SDMEngine/Engine.cpp
@@ -29,6 +29,26 @@ std::string_view sdm::Engine::version() noexcept {
     return "0.4.0-dev";
 }
 
+bool sdm::is_retryable_curl_error(std::uint32_t error_code) noexcept {
+    switch (static_cast<CURLcode>(error_code)) {
+    case CURLE_SSL_ENGINE_NOTFOUND:
+    case CURLE_SSL_ENGINE_SETFAILED:
+    case CURLE_SSL_CERTPROBLEM:
+    case CURLE_SSL_CIPHER:
+    case CURLE_PEER_FAILED_VERIFICATION:
+    case CURLE_SSL_ENGINE_INITFAILED:
+    case CURLE_SSL_CACERT_BADFILE:
+    case CURLE_SSL_CRL_BADFILE:
+    case CURLE_SSL_ISSUER_ERROR:
+    case CURLE_SSL_PINNEDPUBKEYNOTMATCH:
+    case CURLE_SSL_INVALIDCERTSTATUS:
+    case CURLE_SSL_CLIENTCERT:
+        return false;
+    default:
+        return true;
+    }
+}
+
 namespace {
 
 using Clock = std::chrono::steady_clock;
@@ -1046,6 +1066,10 @@ private:
                 : std::string(curl_easy_strerror(curl_result));
             if (transfer.write_failed) {
                 fail_task(task, Result::io_error, message);
+            } else if (!sdm::is_retryable_curl_error(
+                           static_cast<std::uint32_t>(curl_result)
+                       )) {
+                fail_task(task, Result::network_error, message);
             } else {
                 retry_or_fail(task, Result::network_error, message);
             }

--- a/Packages/SDMCore/Sources/SDMEngine/include/SDMEngineDomain.h
+++ b/Packages/SDMCore/Sources/SDMEngine/include/SDMEngineDomain.h
@@ -58,6 +58,10 @@ struct Segment final {
     CommandKind command
 ) noexcept;
 
+[[nodiscard]] bool is_retryable_curl_error(
+    std::uint32_t error_code
+) noexcept;
+
 [[nodiscard]] std::vector<Segment> plan_segments(
     std::uint64_t content_length,
     std::uint32_t requested_connections,

--- a/Packages/SDMCore/Tests/SDMCoreTests/CertificateAuthorityBundleTests.swift
+++ b/Packages/SDMCore/Tests/SDMCoreTests/CertificateAuthorityBundleTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Security
+import XCTest
+@testable import SDMCore
+
+#if os(macOS)
+final class CertificateAuthorityBundleTests: XCTestCase {
+    func testSystemCertificateAuthorityBundleWritesValidPEM() throws {
+        let directory = FileManager.default.temporaryDirectory.appending(
+            path: UUID().uuidString,
+            directoryHint: .isDirectory
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let bundleURL = try CertificateAuthorityBundle.write(to: directory)
+        let contents = try String(contentsOf: bundleURL, encoding: .utf8)
+        let beginMarker = "-----BEGIN CERTIFICATE-----"
+        let endMarker = "-----END CERTIFICATE-----"
+        var isReadingCertificate = false
+        var encodedBody = ""
+        var certificateCount = 0
+
+        for line in contents.split(separator: "\n", omittingEmptySubsequences: false) {
+            switch line {
+            case Substring(beginMarker):
+                XCTAssertFalse(isReadingCertificate)
+                isReadingCertificate = true
+                encodedBody = ""
+            case Substring(endMarker):
+                XCTAssertTrue(isReadingCertificate)
+                let data = try XCTUnwrap(Data(base64Encoded: encodedBody))
+                XCTAssertNotNil(SecCertificateCreateWithData(nil, data as CFData))
+                isReadingCertificate = false
+                certificateCount += 1
+            default:
+                if isReadingCertificate {
+                    XCTAssertLessThanOrEqual(line.utf8.count, 64)
+                    encodedBody.append(contentsOf: line)
+                }
+            }
+        }
+
+        XCTAssertFalse(isReadingCertificate)
+        XCTAssertGreaterThan(certificateCount, 0)
+    }
+}
+#endif

--- a/Packages/SDMCore/Tests/SDMCoreTests/DownloadModelsTests.swift
+++ b/Packages/SDMCore/Tests/SDMCoreTests/DownloadModelsTests.swift
@@ -46,6 +46,20 @@ final class DownloadModelsTests: XCTestCase {
         XCTAssertEqual(sdm_test_validate_command(5, 2), 0)
     }
 
+    func testCurlCertificateFailuresAreNotRetried() {
+        XCTAssertFalse(sdm_test_curl_error_is_retryable(sdm_test_curl_bad_ca_file_error()))
+        XCTAssertFalse(
+            sdm_test_curl_error_is_retryable(sdm_test_curl_peer_verification_error())
+        )
+    }
+
+    func testCurlTransientNetworkFailuresAreRetried() {
+        XCTAssertTrue(sdm_test_curl_error_is_retryable(sdm_test_curl_timeout_error()))
+        XCTAssertTrue(
+            sdm_test_curl_error_is_retryable(sdm_test_curl_could_not_connect_error())
+        )
+    }
+
     func testSegmentSnapshotCalculatesProgress() {
         let segment = DownloadSegmentSnapshot(
             ordinal: 0,

--- a/Packages/SDMCore/Tests/SDMEngineTestSupport/SDMEngineTestSupport.cpp
+++ b/Packages/SDMCore/Tests/SDMEngineTestSupport/SDMEngineTestSupport.cpp
@@ -2,6 +2,7 @@
 
 #include "SDMEngineDomain.h"
 
+#include <curl/curl.h>
 #include <sqlite3.h>
 
 #include <algorithm>
@@ -43,6 +44,26 @@ uint32_t sdm_test_validate_command(uint32_t state, uint32_t command) {
         static_cast<sdm::DownloadState>(state),
         static_cast<sdm::CommandKind>(command)
     ));
+}
+
+bool sdm_test_curl_error_is_retryable(uint32_t error_code) {
+    return sdm::is_retryable_curl_error(error_code);
+}
+
+uint32_t sdm_test_curl_bad_ca_file_error(void) {
+    return CURLE_SSL_CACERT_BADFILE;
+}
+
+uint32_t sdm_test_curl_peer_verification_error(void) {
+    return CURLE_PEER_FAILED_VERIFICATION;
+}
+
+uint32_t sdm_test_curl_timeout_error(void) {
+    return CURLE_OPERATION_TIMEDOUT;
+}
+
+uint32_t sdm_test_curl_could_not_connect_error(void) {
+    return CURLE_COULDNT_CONNECT;
 }
 
 bool sdm_test_create_v1_database(

--- a/Packages/SDMCore/Tests/SDMEngineTestSupport/include/SDMEngineTestSupport.h
+++ b/Packages/SDMCore/Tests/SDMEngineTestSupport/include/SDMEngineTestSupport.h
@@ -26,6 +26,11 @@ size_t sdm_test_plan_segments(
 
 bool sdm_test_can_transition(uint32_t from, uint32_t to);
 uint32_t sdm_test_validate_command(uint32_t state, uint32_t command);
+bool sdm_test_curl_error_is_retryable(uint32_t error_code);
+uint32_t sdm_test_curl_bad_ca_file_error(void);
+uint32_t sdm_test_curl_peer_verification_error(void);
+uint32_t sdm_test_curl_timeout_error(void);
+uint32_t sdm_test_curl_could_not_connect_error(void);
 bool sdm_test_create_v1_database(
     const char *path,
     const char *download_id,


### PR DESCRIPTION
## Summary

- write macOS system trust anchors as structurally valid PEM
- fail deterministic CA and TLS configuration errors immediately while preserving retries for transient network failures
- add regression coverage for certificate parsing and curl retry classification

## Root cause

The exported certificate body was concatenated directly with `-----END CERTIFICATE-----`. Foundation's Base64 line-wrapping option does not append a final newline, so libcurl/OpenSSL could not load the generated CA bundle. Local HTTP fixtures did not exercise TLS, which hid the failure.

## Impact

Real-world HTTPS downloads can now load the macOS system trust anchors and begin segmented transfers. Deterministic certificate configuration failures no longer spend three attempts retrying the same error.

## Validation

- `bash Scripts/test.sh` — 65 checks passed (Safari 8, Chrome 5, Fixture 19, SDMCore 33)
- macOS arm64 Debug app built and codesign validation passed
- generated CA bundle contained 157 matching BEGIN/END markers and parsed successfully with OpenSSL
- ChatWise 26.7.8 HTTPS download followed its redirect and reached approximately 95% across eight range connections with no CA, TLS, or retry errors
