### PR TITLE
Add adaptive HTTP Range segmentation

### DIFF
--- a/App/Sources/Features/Downloads/Details/DownloadConnectionsView.swift
+++ b/App/Sources/Features/Downloads/Details/DownloadConnectionsView.swift
@@ -7,52 +7,62 @@ struct DownloadConnectionsView: View {
     var body: some View {
         if snapshot.segments.isEmpty {
             ContentUnavailableView {
-                Label("No Connection Details", systemImage: "point.3.connected.trianglepath.dotted")
+                Label("No Range Segments", systemImage: "point.3.connected.trianglepath.dotted")
             } description: {
                 if snapshot.engine == .urlSession {
-                    Text("URLSession manages transfer connections internally.")
+                    Text("URLSession manages transfer ranges internally.")
                 } else {
-                    Text("Segment information appears after the server has been probed.")
+                    Text("Range segments appear after the server has been probed.")
                 }
             }
         } else {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(
+                    "Segments are scheduled byte ranges, not simultaneous connections. " +
+                    "Idle connections can split large remaining ranges."
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal)
+
             #if os(macOS)
-            Table(snapshot.segments) {
-                TableColumn("#") { segment in
-                    Text(segment.ordinal + 1, format: .number)
-                        .monospacedDigit()
-                }
-                .width(36)
+                Table(snapshot.segments) {
+                    TableColumn("#") { segment in
+                        Text(segment.ordinal + 1, format: .number)
+                            .monospacedDigit()
+                    }
+                    .width(36)
 
-                TableColumn("Byte Range") { segment in
-                    Text("\(segment.start.formatted())–\(segment.end.formatted())")
-                        .monospacedDigit()
-                        .textSelection(.enabled)
-                }
-                .width(min: 180, ideal: 240)
+                    TableColumn("Byte Range") { segment in
+                        Text("\(segment.start.formatted())–\(segment.end.formatted())")
+                            .monospacedDigit()
+                            .textSelection(.enabled)
+                    }
+                    .width(min: 180, ideal: 240)
 
-                TableColumn("Downloaded") { segment in
-                    Text(DownloadFormatting.bytes(segment.downloadedBytes))
-                        .monospacedDigit()
-                }
-                .width(min: 90, ideal: 120)
+                    TableColumn("Downloaded") { segment in
+                        Text(DownloadFormatting.bytes(segment.downloadedBytes))
+                            .monospacedDigit()
+                    }
+                    .width(min: 90, ideal: 120)
 
-                TableColumn("Progress") { segment in
-                    if let progress = segment.progressFraction {
-                        ProgressView(value: progress) {
-                            Text(progress, format: .percent.precision(.fractionLength(0)))
-                                .monospacedDigit()
+                    TableColumn("Progress") { segment in
+                        if let progress = segment.progressFraction {
+                            ProgressView(value: progress) {
+                                Text(progress, format: .percent.precision(.fractionLength(0)))
+                                    .monospacedDigit()
+                            }
                         }
                     }
+                    .width(min: 150, ideal: 200)
                 }
-                .width(min: 150, ideal: 200)
-            }
             #else
-            List(snapshot.segments) { segment in
-                MobileDownloadSegmentRow(segment: segment)
-            }
-            .listStyle(.insetGrouped)
+                List(snapshot.segments) { segment in
+                    MobileDownloadSegmentRow(segment: segment)
+                }
+                .listStyle(.insetGrouped)
             #endif
+            }
         }
     }
 }

--- a/App/Sources/Features/Downloads/Details/DownloadInfoSection.swift
+++ b/App/Sources/Features/Downloads/Details/DownloadInfoSection.swift
@@ -1,6 +1,6 @@
 enum DownloadInfoSection: String, CaseIterable, Identifiable {
     case overview = "Overview"
-    case connections = "Connections"
+    case connections = "Segments"
     case log = "Log"
 
     var id: Self { self }

--- a/App/Sources/Features/Downloads/Details/DownloadOverviewView.swift
+++ b/App/Sources/Features/Downloads/Details/DownloadOverviewView.swift
@@ -23,7 +23,7 @@ struct DownloadOverviewView: View {
                     "Remaining",
                     value: DownloadFormatting.duration(snapshot.estimatedTimeRemaining)
                 )
-                LabeledContent("Connections", value: snapshot.segments.count.formatted())
+                LabeledContent("Range Segments", value: snapshot.segments.count.formatted())
             }
 
             Section("Location") {

--- a/Docs/SDMCore.md
+++ b/Docs/SDMCore.md
@@ -75,6 +75,14 @@ Recovery changes in-flight tasks to `paused`. Resume uses persisted Range
 offsets and `If-Range` validators; an incompatible response fails before new
 bytes can be written into the partial representation.
 
+For multi-connection libcurl downloads, the initial representation is divided
+evenly across the requested connections. When one connection finishes early,
+the engine reclaims the largest eligible in-flight Range, preserves its
+downloaded prefix, and divides only its remaining tail between two requests.
+This keeps connection slots busy without overlapping byte coverage. Dynamic
+segments are checkpointed with the rest of the download and survive pause,
+restart, and retry.
+
 `remove(_:)` removes task metadata, segment checkpoints, diagnostics, and any
 partial representation. It never removes a finalized destination file.
 

--- a/Fixture/README.md
+++ b/Fixture/README.md
@@ -25,6 +25,7 @@ following fields can be changed there:
 | `file_size` | Virtual `/empty.bin` size in bytes |
 | `bytes_per_second` | `/empty.bin` transfer rate per connection |
 | `chunk_size` | `/empty.bin` streaming write size |
+| `slow_initial_range_bytes_per_second` | Optional rate for a Range beginning at byte zero, used to test adaptive rebalancing |
 
 CLI arguments can override the main multi-connection fields for one run:
 
@@ -33,7 +34,8 @@ python3 Fixture/range_server.py \
   --max-concurrent-transfers <count> \
   --max-ranges-per-request <count> \
   --file-size <bytes> \
-  --bytes-per-second <bytes-per-second>
+  --bytes-per-second <bytes-per-second> \
+  --slow-initial-range-bytes-per-second <bytes-per-second>
 ```
 
 Endpoints:

--- a/Fixture/range_server.py
+++ b/Fixture/range_server.py
@@ -66,6 +66,7 @@ class FixtureConfig:
     file_size: int = DEFAULT_FILE_SIZE
     bytes_per_second: int = DEFAULT_BYTES_PER_SECOND
     chunk_size: int = DEFAULT_CHUNK_SIZE
+    slow_initial_range_bytes_per_second: int = 0
     quiet: bool = False
 
     def __post_init__(self) -> None:
@@ -79,6 +80,8 @@ class FixtureConfig:
             raise ValueError("file_size must be positive")
         if self.bytes_per_second < 0:
             raise ValueError("bytes_per_second cannot be negative")
+        if self.slow_initial_range_bytes_per_second < 0:
+            raise ValueError("slow_initial_range_bytes_per_second cannot be negative")
         if self.chunk_size <= 0:
             raise ValueError("chunk_size must be positive")
 
@@ -468,9 +471,18 @@ class FixtureRequestHandler(BaseHTTPRequestHandler):
         self.end_headers()
 
         if include_body:
+            bytes_per_second = resource.bytes_per_second
+            if (
+                ranges
+                and ranges[0][0] == 0
+                and self.fixture_server.config.slow_initial_range_bytes_per_second
+            ):
+                bytes_per_second = (
+                    self.fixture_server.config.slow_initial_range_bytes_per_second
+                )
             self._write_throttled(
                 body_parts,
-                bytes_per_second=resource.bytes_per_second,
+                bytes_per_second=bytes_per_second,
                 chunk_size=resource.chunk_size,
                 fail_after_bytes=resource.fail_after_bytes,
             )
@@ -643,6 +655,9 @@ def _load_runtime_config(args: argparse.Namespace) -> FixtureConfig:
             "file_size": args.file_size,
             "bytes_per_second": args.bytes_per_second,
             "chunk_size": args.chunk_size,
+            "slow_initial_range_bytes_per_second": (
+                args.slow_initial_range_bytes_per_second
+            ),
             "quiet": args.quiet,
         }.items()
         if value is not None
@@ -660,6 +675,7 @@ def main() -> None:
     parser.add_argument("--file-size", type=int)
     parser.add_argument("--bytes-per-second", type=int)
     parser.add_argument("--chunk-size", type=int)
+    parser.add_argument("--slow-initial-range-bytes-per-second", type=int)
     parser.add_argument("--quiet", action="store_true", default=None)
     args = parser.parse_args()
 

--- a/Packages/SDMCore/Sources/SDMEngine/Engine.cpp
+++ b/Packages/SDMCore/Sources/SDMEngine/Engine.cpp
@@ -53,6 +53,9 @@ namespace {
 
 using Clock = std::chrono::steady_clock;
 
+constexpr std::uint64_t minimum_adaptive_segment_length = 1024 * 1024;
+constexpr std::size_t maximum_segments_per_connection = 8;
+
 std::uint64_t current_milliseconds() noexcept {
     const auto now = std::chrono::system_clock::now().time_since_epoch();
     return static_cast<std::uint64_t>(
@@ -900,6 +903,56 @@ private:
         add_transfer(task, std::move(transfer));
     }
 
+    bool start_segment_transfer(
+        Task &task,
+        std::uint32_t segment_ordinal,
+        std::uint32_t bandwidth_share_count,
+        bool must_use_ranges
+    ) {
+        if (segment_ordinal >= task.segments.size()) {
+            fail_task(task, Result::internal_error, "Segment ordinal was out of bounds");
+            return false;
+        }
+        const auto &segment = task.segments[segment_ordinal];
+        if (segment.next > segment.end) {
+            return true;
+        }
+
+        auto transfer = make_transfer(task, TransferKind::body);
+        if (!transfer) {
+            return false;
+        }
+        transfer->segment_ordinal = segment_ordinal;
+        transfer->start_offset = segment.next;
+        transfer->end_offset = segment.end;
+        transfer->expected_bytes = segment.end - segment.next + 1;
+        apply_bandwidth_limit(*transfer, task, bandwidth_share_count);
+        if (must_use_ranges) {
+            transfer->expects_partial_response = true;
+            const auto range = std::to_string(segment.next) + "-" +
+                std::to_string(segment.end);
+            curl_easy_setopt(transfer->easy, CURLOPT_RANGE, range.c_str());
+            const auto &validator = !task.etag.empty()
+                ? task.etag
+                : task.last_modified;
+            if (!validator.empty()) {
+                const auto header = "If-Range: " + validator;
+                transfer->request_headers = curl_slist_append(
+                    transfer->request_headers,
+                    header.c_str()
+                );
+                curl_easy_setopt(
+                    transfer->easy,
+                    CURLOPT_HTTPHEADER,
+                    transfer->request_headers
+                );
+            }
+        }
+        auto *easy = transfer->easy;
+        add_transfer(task, std::move(transfer));
+        return task.active_handles.contains(easy);
+    }
+
     void start_body(Task &task) {
         if (!task.snapshot.content_length_known && task.segments.empty() &&
             task.write_offset > 0) {
@@ -944,41 +997,19 @@ private:
                 task.segments,
                 [](const Segment &segment) { return segment.next <= segment.end; }
             ));
-            for (auto &segment : task.segments) {
+            for (std::uint32_t ordinal = 0; ordinal < task.segments.size(); ++ordinal) {
+                const auto &segment = task.segments[ordinal];
                 if (segment.next > segment.end) {
                     continue;
                 }
-                auto transfer = make_transfer(task, TransferKind::body);
-                if (!transfer) {
+                if (!start_segment_transfer(
+                        task,
+                        ordinal,
+                        unfinished_count,
+                        must_use_ranges
+                    )) {
                     return;
                 }
-                transfer->segment_ordinal = segment.ordinal;
-                transfer->start_offset = segment.next;
-                transfer->end_offset = segment.end;
-                transfer->expected_bytes = segment.end - segment.next + 1;
-                apply_bandwidth_limit(*transfer, task, unfinished_count);
-                if (must_use_ranges) {
-                    transfer->expects_partial_response = true;
-                    const auto range = std::to_string(segment.next) + "-" +
-                        std::to_string(segment.end);
-                    curl_easy_setopt(transfer->easy, CURLOPT_RANGE, range.c_str());
-                    const auto &validator = !task.etag.empty()
-                        ? task.etag
-                        : task.last_modified;
-                    if (!validator.empty()) {
-                        const auto header = "If-Range: " + validator;
-                        transfer->request_headers = curl_slist_append(
-                            transfer->request_headers,
-                            header.c_str()
-                        );
-                        curl_easy_setopt(
-                            transfer->easy,
-                            CURLOPT_HTTPHEADER,
-                            transfer->request_headers
-                        );
-                    }
-                }
-                add_transfer(task, std::move(transfer));
             }
         }
         publish_snapshot(task);
@@ -1012,6 +1043,107 @@ private:
             CURLOPT_MAX_RECV_SPEED_LARGE,
             static_cast<curl_off_t>(per_transfer)
         );
+    }
+
+    bool rebalance_segmented_task(Task &task) {
+        const auto connection_limit = std::min(
+            task.request.connection_limit,
+            config.maximum_connections_per_download
+        );
+        const auto maximum_segment_count =
+            static_cast<std::size_t>(connection_limit) *
+            maximum_segments_per_connection;
+        if (!task.accepts_ranges || connection_limit < 2 ||
+            task.segments.size() >= maximum_segment_count) {
+            return false;
+        }
+
+        bool rebalanced = false;
+        while (task.active_handles.size() < connection_limit &&
+               task.segments.size() < maximum_segment_count) {
+            CURL *donor_handle = nullptr;
+            std::uint32_t donor_ordinal = std::numeric_limits<std::uint32_t>::max();
+            std::uint64_t largest_remaining_length = 0;
+
+            for (auto *handle : task.active_handles) {
+                const auto transfer_iterator = transfers.find(handle);
+                if (transfer_iterator == transfers.end()) {
+                    continue;
+                }
+                const auto &transfer = *transfer_iterator->second;
+                if (transfer.kind != TransferKind::body ||
+                    transfer.segment_ordinal >= task.segments.size()) {
+                    continue;
+                }
+                const auto &segment = task.segments[transfer.segment_ordinal];
+                if (segment.next > segment.end) {
+                    continue;
+                }
+                const auto remaining_length = segment.end - segment.next + 1;
+                if (remaining_length / 2 < minimum_adaptive_segment_length ||
+                    remaining_length <= largest_remaining_length) {
+                    continue;
+                }
+                donor_handle = handle;
+                donor_ordinal = transfer.segment_ordinal;
+                largest_remaining_length = remaining_length;
+            }
+
+            if (donor_handle == nullptr) {
+                break;
+            }
+
+            auto transfer_iterator = transfers.find(donor_handle);
+            auto donor_transfer = std::move(transfer_iterator->second);
+            transfers.erase(transfer_iterator);
+            curl_multi_remove_handle(multi, donor_handle);
+            task.active_handles.erase(donor_handle);
+            cleanup_easy(*donor_transfer);
+
+            const auto new_ordinal = static_cast<std::uint32_t>(task.segments.size());
+            auto tail = split_segment_tail(
+                task.segments[donor_ordinal],
+                new_ordinal,
+                minimum_adaptive_segment_length
+            );
+            if (!tail) {
+                fail_task(task, Result::internal_error, "Unable to split Range segment");
+                return rebalanced;
+            }
+            const auto split_start = tail->start;
+            task.segments.push_back(*tail);
+
+            if (!start_segment_transfer(
+                    task,
+                    donor_ordinal,
+                    connection_limit,
+                    true
+                ) ||
+                !start_segment_transfer(
+                    task,
+                    new_ordinal,
+                    connection_limit,
+                    true
+                )) {
+                return rebalanced;
+            }
+
+            record_diagnostic(
+                task,
+                DiagnosticLevel::info,
+                0,
+                "Reused an idle connection by splitting Range segment " +
+                    std::to_string(donor_ordinal + 1) + " at byte " +
+                    std::to_string(split_start) + "."
+            );
+            rebalanced = true;
+        }
+
+        if (rebalanced) {
+            task.snapshot.downloaded_bytes = downloaded_bytes(task);
+            publish_snapshot(task);
+        }
+        return rebalanced;
     }
 
     void process_completed_transfers() {
@@ -1105,7 +1237,13 @@ private:
         update_snapshot_segments(task);
         task.snapshot.downloaded_bytes = downloaded_bytes(task);
         if (!task.active_handles.empty()) {
-            publish_snapshot(task);
+            const auto rebalanced = rebalance_segmented_task(task);
+            if (task.snapshot.state != DownloadState::downloading) {
+                return;
+            }
+            if (!rebalanced) {
+                publish_snapshot(task);
+            }
             return;
         }
         if (task.snapshot.content_length_known &&

--- a/Packages/SDMCore/Sources/SDMEngine/SegmentPlanner.cpp
+++ b/Packages/SDMCore/Sources/SDMEngine/SegmentPlanner.cpp
@@ -44,4 +44,29 @@ std::vector<Segment> plan_segments(
     return segments;
 }
 
+std::optional<Segment> split_segment_tail(
+    Segment &segment,
+    std::uint32_t new_ordinal,
+    std::uint64_t minimum_child_length
+) {
+    if (minimum_child_length == 0 || segment.next > segment.end) {
+        return std::nullopt;
+    }
+
+    const auto remaining_length = segment.end - segment.next + 1;
+    if (remaining_length / 2 < minimum_child_length) {
+        return std::nullopt;
+    }
+
+    const auto original_end = segment.end;
+    const auto split_start = segment.next + remaining_length / 2;
+    segment.end = split_start - 1;
+    return Segment{
+        .ordinal = new_ordinal,
+        .start = split_start,
+        .end = original_end,
+        .next = split_start,
+    };
+}
+
 } // namespace sdm

--- a/Packages/SDMCore/Sources/SDMEngine/include/SDMEngineDomain.h
+++ b/Packages/SDMCore/Sources/SDMEngine/include/SDMEngineDomain.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <vector>
 
 namespace sdm {
@@ -66,6 +67,12 @@ struct Segment final {
     std::uint64_t content_length,
     std::uint32_t requested_connections,
     std::uint32_t maximum_connections
+);
+
+[[nodiscard]] std::optional<Segment> split_segment_tail(
+    Segment &segment,
+    std::uint32_t new_ordinal,
+    std::uint64_t minimum_child_length
 );
 
 } // namespace sdm

--- a/Packages/SDMCore/Tests/SDMCoreTests/DownloadModelsTests.swift
+++ b/Packages/SDMCore/Tests/SDMCoreTests/DownloadModelsTests.swift
@@ -37,6 +37,28 @@ final class DownloadModelsTests: XCTestCase {
         XCTAssertEqual(sdm_test_plan_segments(0, 8, 8, &segments, segments.count), 0)
     }
 
+    func testSegmentTailSplitPreservesDownloadedPrefixAndExactCoverage() {
+        var donor = sdm_test_segment_t(ordinal: 2, start: 100, end: 299, next: 160)
+        var tail = sdm_test_segment_t()
+
+        XCTAssertTrue(sdm_test_split_segment_tail(&donor, 8, 50, &tail))
+        XCTAssertEqual(donor.ordinal, 2)
+        XCTAssertEqual(donor.start, 100)
+        XCTAssertEqual(donor.next, 160)
+        XCTAssertEqual(donor.end + 1, tail.start)
+        XCTAssertEqual(tail.ordinal, 8)
+        XCTAssertEqual(tail.next, tail.start)
+        XCTAssertEqual(tail.end, 299)
+    }
+
+    func testSegmentTailSplitRejectsChildrenBelowMinimumSize() {
+        var donor = sdm_test_segment_t(ordinal: 0, start: 0, end: 99, next: 50)
+        var tail = sdm_test_segment_t()
+
+        XCTAssertFalse(sdm_test_split_segment_tail(&donor, 1, 26, &tail))
+        XCTAssertEqual(donor.end, 99)
+    }
+
     func testStateMachineRejectsInvalidCommands() {
         XCTAssertTrue(sdm_test_can_transition(0, 1))
         XCTAssertFalse(sdm_test_can_transition(8, 3))

--- a/Packages/SDMCore/Tests/SDMCoreTests/FixtureServer.swift
+++ b/Packages/SDMCore/Tests/SDMCoreTests/FixtureServer.swift
@@ -10,7 +10,8 @@ final class FixtureServer: @unchecked Sendable {
     init(
         fileSize: Int = 64 * 1024,
         bytesPerSecond: Int = 0,
-        maximumConcurrentTransfers: Int = 8
+        maximumConcurrentTransfers: Int = 8,
+        slowInitialRangeBytesPerSecond: Int = 0
     ) throws {
         let repositoryURL = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
@@ -29,6 +30,8 @@ final class FixtureServer: @unchecked Sendable {
             "--file-size", String(fileSize),
             "--bytes-per-second", String(bytesPerSecond),
             "--max-concurrent-transfers", String(maximumConcurrentTransfers),
+            "--slow-initial-range-bytes-per-second",
+            String(slowInitialRangeBytesPerSecond),
             "--quiet",
         ]
         process.standardOutput = output

--- a/Packages/SDMCore/Tests/SDMCoreTests/SegmentedDownloadTests.swift
+++ b/Packages/SDMCore/Tests/SDMCoreTests/SegmentedDownloadTests.swift
@@ -49,4 +49,80 @@ final class SegmentedDownloadTests: XCTestCase {
         }
         await manager.shutdown()
     }
+
+    func testIdleConnectionSplitsLargestRemainingRange() async throws {
+        let fileSize = 8 * 1024 * 1024
+        let fixture = try FixtureServer(
+            fileSize: fileSize,
+            bytesPerSecond: 8 * 1024 * 1024,
+            maximumConcurrentTransfers: 2,
+            slowInitialRangeBytesPerSecond: 256 * 1024
+        )
+        defer { fixture.stop() }
+        let root = FileManager.default.temporaryDirectory
+            .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let configuration = DownloadManagerConfiguration(
+            databaseURL: root.appending(path: "downloads.sqlite3"),
+            temporaryDirectory: root.appending(path: "partial", directoryHint: .isDirectory)
+        )
+        let manager = try DownloadManager(configuration: configuration)
+        let id = try await manager.enqueue(DownloadRequest(
+            url: fixture.fileURL,
+            destinationDirectory: root.appending(path: "adaptive", directoryHint: .isDirectory),
+            connectionLimit: 2
+        ))
+        let rebalanced = try await waitForSnapshot(
+            manager,
+            id: id,
+            timeout: .seconds(12)
+        ) {
+            $0.state == .downloading && $0.segments.count > 2
+        }
+        XCTAssertGreaterThan(rebalanced.downloadedBytes, 0)
+        await manager.shutdown()
+
+        let recoveredManager = try DownloadManager(configuration: configuration)
+        let recovered = try await waitForSnapshot(recoveredManager, id: id) {
+            $0.state == .paused
+        }
+        XCTAssertGreaterThan(recovered.segments.count, 2)
+        XCTAssertGreaterThanOrEqual(recovered.downloadedBytes, rebalanced.downloadedBytes)
+
+        try await recoveredManager.resume(id)
+        let completed = try await waitForSnapshot(
+            recoveredManager,
+            id: id,
+            timeout: .seconds(12)
+        ) {
+            $0.state == .completed || $0.state == .failed
+        }
+
+        XCTAssertEqual(completed.state, .completed, completed.error?.message ?? "")
+        XCTAssertGreaterThan(completed.segments.count, 2)
+        XCTAssertTrue(completed.segments.allSatisfy {
+            $0.downloadedBytes == $0.totalBytes
+        })
+
+        let orderedSegments = completed.segments.sorted { $0.start < $1.start }
+        var expectedStart: UInt64 = 0
+        for segment in orderedSegments {
+            XCTAssertEqual(segment.start, expectedStart)
+            expectedStart = segment.end + 1
+        }
+        XCTAssertEqual(expectedStart, UInt64(fileSize))
+
+        let destinationURL = try XCTUnwrap(completed.destinationURL)
+        XCTAssertEqual(
+            try Data(contentsOf: destinationURL),
+            fixturePattern(offset: 0, length: fileSize)
+        )
+        let events = try await recoveredManager.diagnosticEvents(for: id)
+        XCTAssertTrue(events.contains {
+            $0.message.contains("Reused an idle connection by splitting Range segment")
+        })
+        await recoveredManager.shutdown()
+    }
 }

--- a/Packages/SDMCore/Tests/SDMEngineTestSupport/SDMEngineTestSupport.cpp
+++ b/Packages/SDMCore/Tests/SDMEngineTestSupport/SDMEngineTestSupport.cpp
@@ -32,6 +32,44 @@ size_t sdm_test_plan_segments(
     return plan.size();
 }
 
+bool sdm_test_split_segment_tail(
+    sdm_test_segment_t *segment,
+    uint32_t new_ordinal,
+    uint64_t minimum_child_length,
+    sdm_test_segment_t *new_segment
+) {
+    if (segment == nullptr || new_segment == nullptr) {
+        return false;
+    }
+    auto source = sdm::Segment{
+        .ordinal = segment->ordinal,
+        .start = segment->start,
+        .end = segment->end,
+        .next = segment->next,
+    };
+    const auto split = sdm::split_segment_tail(
+        source,
+        new_ordinal,
+        minimum_child_length
+    );
+    if (!split) {
+        return false;
+    }
+    *segment = sdm_test_segment_t{
+        .ordinal = source.ordinal,
+        .start = source.start,
+        .end = source.end,
+        .next = source.next,
+    };
+    *new_segment = sdm_test_segment_t{
+        .ordinal = split->ordinal,
+        .start = split->start,
+        .end = split->end,
+        .next = split->next,
+    };
+    return true;
+}
+
 bool sdm_test_can_transition(uint32_t from, uint32_t to) {
     return sdm::can_transition(
         static_cast<sdm::DownloadState>(from),

--- a/Packages/SDMCore/Tests/SDMEngineTestSupport/include/SDMEngineTestSupport.h
+++ b/Packages/SDMCore/Tests/SDMEngineTestSupport/include/SDMEngineTestSupport.h
@@ -24,6 +24,13 @@ size_t sdm_test_plan_segments(
     size_t capacity
 );
 
+bool sdm_test_split_segment_tail(
+    sdm_test_segment_t *segment,
+    uint32_t new_ordinal,
+    uint64_t minimum_child_length,
+    sdm_test_segment_t *new_segment
+);
+
 bool sdm_test_can_transition(uint32_t from, uint32_t to);
 uint32_t sdm_test_validate_command(uint32_t state, uint32_t command);
 bool sdm_test_curl_error_is_retryable(uint32_t error_code);

--- a/README.md
+++ b/README.md
@@ -6,13 +6,15 @@ stack offers a C++/libcurl engine and a native URLSession engine behind one
 Swift API, distributed through local SwiftPM packages and a Tuist-generated
 Xcode project.
 
-The core download stack now supports HTTP probing, single and segmented Range
-transfers, pause/resume/cancel/retry, bounded scheduling and bandwidth,
-SQLite-backed recovery, and atomic file finalization. The SwiftUI application
+The core download stack now supports HTTP probing, single and adaptively
+segmented Range transfers, pause/resume/cancel/retry, bounded scheduling and
+bandwidth, SQLite-backed recovery, and atomic file finalization. Idle
+connections split the largest eligible remaining Range so uneven transfers do
+not leave available connection capacity unused. The SwiftUI application
 uses `DownloadService` to enqueue direct URLs, observe engine snapshots, show
 filterable progress and status, and issue pause, resume, cancel, retry, and
 remove commands. Every task can open a live Info window with transfer metadata,
-per-connection progress, lifecycle controls, and a bounded persistent activity
+per-Range progress, lifecycle controls, and a bounded persistent activity
 history. Project planning is maintained outside the application repository in
 the surrounding workspace.
 
@@ -23,7 +25,7 @@ existing tasks remain attached to the engine that created them.
 
 | Capability | libcurl | URLSession |
 | --- | --- | --- |
-| Multi-connection Range transfers | Yes | No |
+| Adaptive multi-connection Range transfers | Yes | No |
 | Per-download bandwidth limit | Yes | No |
 | Persistent recovery | Yes | Yes |
 | Native background transfer | No | Yes |


### PR DESCRIPTION
## Summary

- reuse idle connections by splitting the largest eligible remaining HTTP Range
- preserve downloaded prefixes and `If-Range` validation while preventing gaps and overlaps
- cap adaptive segments and avoid splitting small tails
- present dynamic work as Range segments rather than simultaneous connections
- add uneven-speed, persistence recovery, exact coverage, fixture, and documentation updates

## Root cause

The engine divided the representation into a fixed set of equal ranges once. When one range completed early, that connection stayed idle while slower ranges continued, so the implementation provided parallel downloads without adaptive scheduling.

## Impact

Uneven real-world transfers now keep the configured connection capacity in use. Dynamic segment checkpoints survive pause, restart, and retry, and the UI no longer reports the growing segment count as the number of live connections.

## Validation

- `swift test --package-path Packages/SDMCore` — 36 tests passed
- `python3 -m unittest discover -s Fixture/tests -v` — 19 tests passed
- `xcodebuild test -workspace SDM.xcworkspace -scheme SDMApp -destination 'platform=macOS' -only-testing:SDMAppTests` — 23 tests passed
- signed macOS Debug App built successfully
- ChatWise 117.4 MB DMG completed successfully in the App
