### PR TITLE
Add multi-select download actions

### DIFF
--- a/App/Sources/Application/Commands/DownloadCommand.swift
+++ b/App/Sources/Application/Commands/DownloadCommand.swift
@@ -35,4 +35,15 @@ enum DownloadCommand: CaseIterable, Identifiable {
         default: nil
         }
     }
+
+    func title(forSelectionCount count: Int) -> String {
+        guard count > 1 else { return title }
+        return switch self {
+        case .pause: "Pause \(count) Downloads"
+        case .resume: "Resume \(count) Downloads"
+        case .cancel: "Cancel \(count) Downloads"
+        case .retry: "Retry \(count) Downloads"
+        case .remove: "Remove \(count) from History"
+        }
+    }
 }

--- a/App/Sources/Application/ContentView.swift
+++ b/App/Sources/Application/ContentView.swift
@@ -7,7 +7,9 @@ struct ContentView: View {
     let service: DownloadService
     @AppStorage(AppStorageKey.defaultConnectionCount) private var defaultConnectionCount = 8
     @State private var selection: DownloadFilter? = .all
-    @State private var selectedDownloadID: DownloadID?
+    @State private var selectedDownloadIDs: Set<DownloadID> = []
+    @State private var downloadsPendingRemoval: Set<DownloadID> = []
+    @State private var confirmsBatchRemoval = false
     @State private var showsNewDownload = false
     @State private var presentedError: PresentedDownloadError?
 
@@ -22,8 +24,18 @@ struct ContentView: View {
     }
 
     private var selectedSnapshot: DownloadSnapshot? {
-        guard let selectedDownloadID else { return nil }
-        return service.snapshots.first { $0.id == selectedDownloadID }
+        guard selectedDownloadIDs.count == 1, let selectedID = selectedDownloadIDs.first else {
+            return nil
+        }
+        return service.snapshots.first { $0.id == selectedID }
+    }
+
+    private var selectedCommands: [DownloadCommand] {
+        service.snapshots.commonCommands(for: selectedDownloadIDs)
+    }
+
+    private var selectedDownloadsAreBusy: Bool {
+        !service.commandInFlightIDs.isDisjoint(with: selectedDownloadIDs)
     }
 
     private var availableNewURLAction: (() -> Void)? {
@@ -62,8 +74,23 @@ struct ContentView: View {
                 dismissButton: .default(Text("OK"))
             )
         }
+        .confirmationDialog(
+            removalConfirmationTitle,
+            isPresented: $confirmsBatchRemoval
+        ) {
+            Button("Remove from History", role: .destructive, action: removePendingDownloads)
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(
+                "Partial data and diagnostics for the selected downloads will be deleted. "
+                    + "Downloaded files will be kept."
+            )
+        }
         .onChange(of: selection) { _, _ in
-            selectedDownloadID = nil
+            selectedDownloadIDs.removeAll()
+        }
+        .onChange(of: Set(service.snapshots.map(\.id))) { _, availableIDs in
+            selectedDownloadIDs.formIntersection(availableIDs)
         }
         .onOpenURL(perform: handleExternalURL)
         .onReceive(
@@ -97,7 +124,7 @@ struct ContentView: View {
                 .keyboardShortcut("n", modifiers: .command)
             }
         } else {
-            Table(visibleSnapshots, selection: $selectedDownloadID) {
+            Table(visibleSnapshots, selection: $selectedDownloadIDs) {
                 TableColumn("Name") { snapshot in
                     DownloadNameCell(snapshot: snapshot)
                 }
@@ -153,14 +180,27 @@ struct ContentView: View {
                 }
                 .width(34)
             }
+            .background(MutedTableSelection(selectedIDs: selectedDownloadIDs))
             .contextMenu(forSelectionType: DownloadID.self) { ids in
-                if let id = ids.first {
+                if ids.count == 1, let id = ids.first {
                     Button("Show Info", systemImage: "info.circle") {
                         openInfo(id)
                     }
                 }
+
+                ForEach(service.snapshots.commonCommands(for: ids)) { command in
+                    Button(role: command.role) {
+                        performSelectedCommand(command, on: ids)
+                    } label: {
+                        Label(
+                            command.title(forSelectionCount: ids.count),
+                            systemImage: command.systemImage
+                        )
+                    }
+                    .disabled(!service.commandInFlightIDs.isDisjoint(with: ids))
+                }
             } primaryAction: { ids in
-                if let id = ids.first {
+                if ids.count == 1, let id = ids.first {
                     openInfo(id)
                 }
             }
@@ -175,15 +215,18 @@ struct ContentView: View {
                     openInfo(selectedSnapshot.id)
                 }
                 .keyboardShortcut("i", modifiers: .command)
+            }
 
-                ForEach(selectedSnapshot.availableCommands) { command in
-                    Button(role: command.role) {
-                        perform(command, on: selectedSnapshot.id)
-                    } label: {
-                        Label(command.title, systemImage: command.systemImage)
-                    }
-                    .disabled(service.commandInFlightIDs.contains(selectedSnapshot.id))
+            ForEach(selectedCommands) { command in
+                Button(role: command.role) {
+                    performSelectedCommand(command, on: selectedDownloadIDs)
+                } label: {
+                    Label(
+                        command.title(forSelectionCount: selectedDownloadIDs.count),
+                        systemImage: command.systemImage
+                    )
                 }
+                .disabled(selectedDownloadsAreBusy)
             }
         }
 
@@ -212,9 +255,9 @@ struct ContentView: View {
     private func perform(_ command: DownloadCommand, on id: DownloadID) {
         Task { @MainActor in
             do {
-                try await service.perform(command, on: id)
-                if command == .remove, selectedDownloadID == id {
-                    selectedDownloadID = nil
+                let didPerform = try await service.perform(command, on: id)
+                if didPerform, command == .remove {
+                    selectedDownloadIDs.remove(id)
                 }
             } catch {
                 presentedError = PresentedDownloadError(
@@ -229,12 +272,64 @@ struct ContentView: View {
         Task { @MainActor in
             do {
                 try await service.deleteDownloadedFileAndHistory(for: snapshot.id)
-                if selectedDownloadID == snapshot.id {
-                    selectedDownloadID = nil
-                }
+                selectedDownloadIDs.remove(snapshot.id)
             } catch {
                 presentedError = PresentedDownloadError(
                     title: "Could Not Delete Downloaded File",
+                    error: error
+                )
+            }
+        }
+    }
+
+    private var removalConfirmationTitle: String {
+        if downloadsPendingRemoval.count == 1 {
+            "Remove Download from History?"
+        } else {
+            "Remove \(downloadsPendingRemoval.count) Downloads from History?"
+        }
+    }
+
+    private func performSelectedCommand(
+        _ command: DownloadCommand,
+        on ids: Set<DownloadID>
+    ) {
+        guard !ids.isEmpty else { return }
+        if command == .remove {
+            confirmRemoval(of: ids)
+        } else {
+            perform(command, on: ids)
+        }
+    }
+
+    private func perform(_ command: DownloadCommand, on ids: Set<DownloadID>) {
+        Task { @MainActor in
+            do {
+                _ = try await service.perform(command, on: ids)
+            } catch {
+                presentedError = PresentedDownloadError(
+                    title: "Could Not \(command.title) Downloads",
+                    error: error
+                )
+            }
+        }
+    }
+
+    private func confirmRemoval(of ids: Set<DownloadID>) {
+        downloadsPendingRemoval = ids
+        confirmsBatchRemoval = true
+    }
+
+    private func removePendingDownloads() {
+        let ids = downloadsPendingRemoval
+        Task { @MainActor in
+            do {
+                let removedIDs = try await service.perform(.remove, on: ids)
+                selectedDownloadIDs.subtract(removedIDs)
+                downloadsPendingRemoval.removeAll()
+            } catch {
+                presentedError = PresentedDownloadError(
+                    title: "Could Not Remove Downloads",
                     error: error
                 )
             }

--- a/App/Sources/Features/Downloads/DownloadPresentation.swift
+++ b/App/Sources/Features/Downloads/DownloadPresentation.swift
@@ -84,6 +84,17 @@ extension DownloadSnapshot {
     }
 }
 
+extension Collection where Element == DownloadSnapshot {
+    func commonCommands(for selectedIDs: Set<DownloadID>) -> [DownloadCommand] {
+        guard !selectedIDs.isEmpty else { return [] }
+        let selectedSnapshots = filter { selectedIDs.contains($0.id) }
+        guard selectedSnapshots.count == selectedIDs.count else { return [] }
+        return DownloadCommand.allCases.filter { command in
+            selectedSnapshots.allSatisfy { $0.state.allows(command) }
+        }
+    }
+}
+
 extension DownloadSegmentSnapshot {
     var progressFraction: Double? {
         guard totalBytes > 0 else { return nil }

--- a/App/Sources/Features/Downloads/DownloadService.swift
+++ b/App/Sources/Features/Downloads/DownloadService.swift
@@ -163,9 +163,14 @@ final class DownloadService {
         selectedEngine = engine
     }
 
-    func perform(_ command: DownloadCommand, on id: DownloadID) async throws {
+    @discardableResult
+    func perform(_ command: DownloadCommand, on id: DownloadID) async throws -> Bool {
+        guard let snapshot = snapshots.first(where: { $0.id == id }),
+              snapshot.state.allows(command) else {
+            return false
+        }
         let manager = try requiredManager()
-        guard commandInFlightIDs.insert(id).inserted else { return }
+        guard commandInFlightIDs.insert(id).inserted else { return false }
         defer { commandInFlightIDs.remove(id) }
 
         switch command {
@@ -180,6 +185,26 @@ final class DownloadService {
         case .remove:
             try await manager.remove(id)
         }
+        return true
+    }
+
+    @discardableResult
+    func perform(
+        _ command: DownloadCommand,
+        on ids: Set<DownloadID>
+    ) async throws -> Set<DownloadID> {
+        guard commandInFlightIDs.isDisjoint(with: ids) else {
+            throw ServiceError.unavailable(
+                "Another operation is already in progress for one of the selected downloads."
+            )
+        }
+        var performedIDs: Set<DownloadID> = []
+        for id in ids {
+            if try await perform(command, on: id) {
+                performedIDs.insert(id)
+            }
+        }
+        return performedIDs
     }
 
     func logs(for id: DownloadID) -> [DownloadDiagnosticEvent] {

--- a/App/Sources/Features/Downloads/Mac/MutedTableSelection.swift
+++ b/App/Sources/Features/Downloads/Mac/MutedTableSelection.swift
@@ -1,0 +1,158 @@
+#if os(macOS)
+import SDMCore
+import SwiftUI
+
+/// Keeps table selection visible without letting the app accent color overpower row content.
+struct MutedTableSelection: NSViewRepresentable {
+    let selectedIDs: Set<DownloadID>
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeNSView(context: Context) -> MarkerView {
+        let marker = MarkerView()
+        marker.didMoveToWindow = { [weak marker, weak coordinator = context.coordinator] in
+            guard let marker, let coordinator else { return }
+            connectCoordinator(coordinator, from: marker)
+        }
+        return marker
+    }
+
+    func updateNSView(_ marker: MarkerView, context: Context) {
+        connectCoordinator(context.coordinator, from: marker)
+        context.coordinator.selectionDidUpdate(selectedIDs)
+    }
+
+    private func connectCoordinator(_ coordinator: Coordinator, from marker: NSView) {
+        Task { @MainActor [weak marker, weak coordinator] in
+            for _ in 0..<10 {
+                guard let marker, let coordinator else { return }
+                if let tableView = mainTableView(from: marker) {
+                    coordinator.connect(to: tableView)
+                    return
+                }
+                try? await Task.sleep(for: .milliseconds(50))
+            }
+        }
+    }
+
+    private func mainTableView(from marker: NSView) -> NSTableView? {
+        guard let contentView = marker.window?.contentView else { return nil }
+        return allTableViews(in: contentView).first { $0.numberOfColumns > 1 }
+    }
+
+    private func allTableViews(in view: NSView) -> [NSTableView] {
+        var result: [NSTableView] = []
+        if let tableView = view as? NSTableView {
+            result.append(tableView)
+        }
+        for subview in view.subviews {
+            result.append(contentsOf: allTableViews(in: subview))
+        }
+        return result
+    }
+
+    final class MarkerView: NSView {
+        var didMoveToWindow: (() -> Void)?
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            didMoveToWindow?()
+        }
+    }
+
+    @MainActor
+    final class Coordinator: NSObject {
+        private weak var tableView: NSTableView?
+        private weak var clipView: NSClipView?
+        private var selectedIDs: Set<DownloadID> = []
+        private var selectionUpdateTask: Task<Void, Never>?
+
+        func selectionDidUpdate(_ selectedIDs: Set<DownloadID>) {
+            self.selectedIDs = selectedIDs
+            scheduleSelectionUpdate()
+        }
+
+        func connect(to tableView: NSTableView) {
+            guard self.tableView !== tableView else {
+                scheduleSelectionUpdate()
+                return
+            }
+            if let currentTableView = self.tableView {
+                NotificationCenter.default.removeObserver(
+                    self,
+                    name: NSTableView.selectionDidChangeNotification,
+                    object: currentTableView
+                )
+            }
+            if let currentClipView = clipView {
+                NotificationCenter.default.removeObserver(
+                    self,
+                    name: NSView.boundsDidChangeNotification,
+                    object: currentClipView
+                )
+            }
+            self.tableView = tableView
+            tableView.selectionHighlightStyle = .none
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(selectionDidChange),
+                name: NSTableView.selectionDidChangeNotification,
+                object: tableView
+            )
+            let clipView = tableView.enclosingScrollView?.contentView
+            self.clipView = clipView
+            if let clipView {
+                clipView.postsBoundsChangedNotifications = true
+                NotificationCenter.default.addObserver(
+                    self,
+                    selector: #selector(visibleRowsDidChange),
+                    name: NSView.boundsDidChangeNotification,
+                    object: clipView
+                )
+            }
+            scheduleSelectionUpdate()
+        }
+
+        @objc private func selectionDidChange() {
+            scheduleSelectionUpdate()
+        }
+
+        @objc private func visibleRowsDidChange() {
+            scheduleSelectionUpdate()
+        }
+
+        private func scheduleSelectionUpdate() {
+            selectionUpdateTask?.cancel()
+            let expectedIDs = selectedIDs
+            selectionUpdateTask = Task { @MainActor [weak self] in
+                await Task.yield()
+                guard !Task.isCancelled, self?.selectedIDs == expectedIDs else { return }
+                self?.updateSelectionBackgrounds()
+
+                for delay in [30, 120] {
+                    do {
+                        try await Task.sleep(for: .milliseconds(delay))
+                    } catch {
+                        return
+                    }
+                    guard !Task.isCancelled, self?.selectedIDs == expectedIDs else { return }
+                    self?.updateSelectionBackgrounds()
+                }
+            }
+        }
+
+        private func updateSelectionBackgrounds() {
+            guard let tableView else { return }
+            let selectedRows = tableView.selectedRowIndexes
+            tableView.enumerateAvailableRowViews { rowView, row in
+                rowView.backgroundColor = selectedRows.contains(row)
+                    ? NSColor.controlAccentColor.withAlphaComponent(0.14)
+                    : .clear
+                rowView.needsDisplay = true
+            }
+        }
+    }
+}
+#endif

--- a/App/Sources/Features/Downloads/Mobile/MobileContentView.swift
+++ b/App/Sources/Features/Downloads/Mobile/MobileContentView.swift
@@ -3,9 +3,13 @@ import SDMCore
 import SwiftUI
 
 struct MobileContentView: View {
+    @Environment(\.editMode) private var editMode
     @Bindable var service: DownloadService
     @AppStorage(AppStorageKey.defaultConnectionCount) private var defaultConnectionCount = 8
     @State private var selection: DownloadFilter? = .all
+    @State private var selectedDownloadIDs: Set<DownloadID> = []
+    @State private var downloadsPendingRemoval: Set<DownloadID> = []
+    @State private var confirmsBatchRemoval = false
     @State private var showsNewDownload = false
     @State private var showsSettings = false
     @State private var presentedError: PresentedDownloadError?
@@ -18,6 +22,18 @@ struct MobileContentView: View {
         service.snapshots
             .filter { selectedFilter.includes($0.state) }
             .sorted { $0.updatedAt > $1.updatedAt }
+    }
+
+    private var selectedCommands: [DownloadCommand] {
+        service.snapshots.commonCommands(for: selectedDownloadIDs)
+    }
+
+    private var selectedDownloadsAreBusy: Bool {
+        !service.commandInFlightIDs.isDisjoint(with: selectedDownloadIDs)
+    }
+
+    private var isEditing: Bool {
+        editMode?.wrappedValue.isEditing == true
     }
 
     var body: some View {
@@ -48,7 +64,7 @@ struct MobileContentView: View {
                             Button("New Download", action: presentNewDownload)
                         }
                     } else {
-                        List(visibleSnapshots) { snapshot in
+                        List(visibleSnapshots, selection: $selectedDownloadIDs) { snapshot in
                             NavigationLink(value: snapshot.id) {
                                 MobileDownloadRow(snapshot: snapshot)
                             }
@@ -73,12 +89,39 @@ struct MobileContentView: View {
                     DownloadInfoView(service: service, downloadID: id)
                 }
                 .toolbar {
+                    ToolbarItem(placement: .topBarLeading) {
+                        EditButton()
+                            .disabled(visibleSnapshots.isEmpty)
+                    }
+
                     ToolbarItemGroup(placement: .topBarTrailing) {
                         Button("Settings", systemImage: "gearshape") {
                             showsSettings = true
                         }
                         Button("New Download", systemImage: "plus", action: presentNewDownload)
                             .disabled(service.initializationError != nil)
+                    }
+
+                    if isEditing {
+                        ToolbarItemGroup(placement: .bottomBar) {
+                            Spacer()
+                            ForEach(selectedCommands) { command in
+                                Button(role: command.role) {
+                                    performSelectedCommand(
+                                        command,
+                                        on: selectedDownloadIDs
+                                    )
+                                } label: {
+                                    Label(
+                                        command.title(
+                                            forSelectionCount: selectedDownloadIDs.count
+                                        ),
+                                        systemImage: command.systemImage
+                                    )
+                                }
+                                .disabled(selectedDownloadsAreBusy)
+                            }
+                        }
                     }
                 }
             }
@@ -117,6 +160,24 @@ struct MobileContentView: View {
                 dismissButton: .default(Text("OK"))
             )
         }
+        .confirmationDialog(
+            removalConfirmationTitle,
+            isPresented: $confirmsBatchRemoval
+        ) {
+            Button("Remove from History", role: .destructive, action: removePendingDownloads)
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(
+                "Partial data and diagnostics for the selected downloads will be deleted. "
+                    + "Downloaded files will be kept."
+            )
+        }
+        .onChange(of: selection) { _, _ in
+            finishEditing()
+        }
+        .onChange(of: Set(service.snapshots.map(\.id))) { _, availableIDs in
+            selectedDownloadIDs.formIntersection(availableIDs)
+        }
         .onOpenURL(perform: handleExternalURL)
     }
 
@@ -137,7 +198,10 @@ struct MobileContentView: View {
     private func perform(_ command: DownloadCommand, on id: DownloadID) {
         Task { @MainActor in
             do {
-                try await service.perform(command, on: id)
+                let didPerform = try await service.perform(command, on: id)
+                if didPerform, command == .remove {
+                    selectedDownloadIDs.remove(id)
+                }
             } catch {
                 presentedError = PresentedDownloadError(
                     title: "Could Not \(command.title)",
@@ -145,6 +209,64 @@ struct MobileContentView: View {
                 )
             }
         }
+    }
+
+    private var removalConfirmationTitle: String {
+        if downloadsPendingRemoval.count == 1 {
+            "Remove Download from History?"
+        } else {
+            "Remove \(downloadsPendingRemoval.count) Downloads from History?"
+        }
+    }
+
+    private func performSelectedCommand(
+        _ command: DownloadCommand,
+        on ids: Set<DownloadID>
+    ) {
+        guard !ids.isEmpty else { return }
+        if command == .remove {
+            downloadsPendingRemoval = ids
+            confirmsBatchRemoval = true
+        } else {
+            perform(command, on: ids)
+        }
+    }
+
+    private func perform(_ command: DownloadCommand, on ids: Set<DownloadID>) {
+        Task { @MainActor in
+            do {
+                _ = try await service.perform(command, on: ids)
+            } catch {
+                presentedError = PresentedDownloadError(
+                    title: "Could Not \(command.title) Downloads",
+                    error: error
+                )
+            }
+        }
+    }
+
+    private func removePendingDownloads() {
+        let ids = downloadsPendingRemoval
+        Task { @MainActor in
+            do {
+                let removedIDs = try await service.perform(.remove, on: ids)
+                selectedDownloadIDs.subtract(removedIDs)
+                downloadsPendingRemoval.removeAll()
+                if selectedDownloadIDs.isEmpty {
+                    editMode?.wrappedValue = .inactive
+                }
+            } catch {
+                presentedError = PresentedDownloadError(
+                    title: "Could Not Remove Downloads",
+                    error: error
+                )
+            }
+        }
+    }
+
+    private func finishEditing() {
+        selectedDownloadIDs.removeAll()
+        editMode?.wrappedValue = .inactive
     }
 
     private func handleExternalURL(_ callbackURL: URL) {

--- a/App/Tests/SDMAppTests.swift
+++ b/App/Tests/SDMAppTests.swift
@@ -210,6 +210,60 @@ final class SDMAppTests: XCTestCase {
         XCTAssertFalse(DownloadState.completed.allows(.cancel))
     }
 
+    func testBatchCommandsAreTheIntersectionOfEverySelectedDownload() throws {
+        let completed = DownloadSnapshot(
+            id: DownloadID(),
+            sourceURL: try XCTUnwrap(URL(string: "https://example.com/completed.zip")),
+            filename: "completed.zip",
+            state: .completed
+        )
+        let failed = DownloadSnapshot(
+            id: DownloadID(),
+            sourceURL: try XCTUnwrap(URL(string: "https://example.com/failed.zip")),
+            filename: "failed.zip",
+            state: .failed
+        )
+        let downloading = DownloadSnapshot(
+            id: DownloadID(),
+            sourceURL: try XCTUnwrap(URL(string: "https://example.com/downloading.zip")),
+            filename: "downloading.zip",
+            state: .downloading
+        )
+        let snapshots = [completed, failed, downloading]
+
+        XCTAssertEqual(
+            snapshots.commonCommands(for: [failed.id, downloading.id]).map(\.title),
+            ["Cancel"]
+        )
+        XCTAssertEqual(
+            snapshots.commonCommands(for: [completed.id, failed.id]).map(\.title),
+            ["Remove from History"]
+        )
+        XCTAssertTrue(
+            snapshots.commonCommands(for: [completed.id, downloading.id]).isEmpty
+        )
+        XCTAssertTrue(snapshots.commonCommands(for: []).isEmpty)
+        XCTAssertTrue(snapshots.commonCommands(for: [DownloadID()]).isEmpty)
+    }
+
+    @MainActor
+    func testServiceIgnoresCommandsUnavailableForTheCurrentState() async throws {
+        let failed = DownloadSnapshot(
+            id: DownloadID(),
+            sourceURL: try XCTUnwrap(URL(string: "https://example.com/failed.zip")),
+            filename: "failed.zip",
+            state: .failed
+        )
+        let service = DownloadService.preview(snapshots: [failed])
+
+        let didPerform = try await service.perform(.pause, on: failed.id)
+        let performedIDs = try await service.perform(.pause, on: [failed.id])
+
+        XCTAssertFalse(didPerform)
+        XCTAssertTrue(performedIDs.isEmpty)
+        XCTAssertFalse(service.commandInFlightIDs.contains(failed.id))
+    }
+
     func testProgressFractionIsBounded() throws {
         let snapshot = DownloadSnapshot(
             id: DownloadID(),

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ Completed, failed, cancelled, and paused tasks remain until the user chooses
 diagnostics, but never deletes a finalized file. **Delete Downloaded File** is a
 separate confirmed action. Finalized downloads stay in Downloads or another
 user-selected directory, and security-scoped bookmarks preserve access to
-custom destinations across launches.
+custom destinations across launches. Select multiple rows on macOS, or tap
+**Edit** on iOS and iPadOS, to remove several eligible tasks from history at
+once.
 
 ## Build
 


### PR DESCRIPTION
## Summary

- add multi-row selection on macOS and edit-mode multi-selection on iOS/iPadOS
- expose only the lifecycle actions supported by every selected download
- guard service commands against stale or invalid download states
- keep macOS selection visible with a muted accent background and synchronize it during scrolling/selection updates
- add batch-action coverage and update the download-history documentation

## Why

Bulk history and lifecycle operations should work consistently without exposing actions that are invalid for part of the selection. The macOS table also needs a lighter selection treatment that remains synchronized with SwiftUI's selection state.

## Validation

- `bash Scripts/test.sh` (extension tests, 19 fixture tests, 36 SDMCore tests)
- `xcodebuild test -quiet -workspace SDM.xcworkspace -scheme SDMApp -destination 'platform=macOS,arch=arm64'`
- `git diff --check`
