### PR TITLE
Add LookInside debug integration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,6 +210,21 @@ jobs:
           codesign -dv --verbose=4 "$EXTENSION_PATH" 2>&1 | \
             grep -F 'Authority=Developer ID Application:'
 
+          app_bundle_identifier="$(
+            plutil -extract CFBundleIdentifier raw -o - \
+              "$APP_PATH/Contents/Info.plist"
+          )"
+          app_identifier="$(
+            codesign -d --entitlements - --xml "$APP_PATH" 2>/dev/null | \
+              plutil -extract 'com\.apple\.application-identifier' raw -o - -
+          )"
+          expected_app_identifier="VB7MJ8R223.${app_bundle_identifier}"
+          if [[ "$app_identifier" != "$expected_app_identifier" ]]; then
+            echo "Unexpected application identifier: $app_identifier" >&2
+            echo "Expected: $expected_app_identifier" >&2
+            exit 1
+          fi
+
       - name: Submit for notarization
         env:
           API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}

--- a/App/Support/SDMApp-Debug.entitlements
+++ b/App/Support/SDMApp-Debug.entitlements
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.application-identifier</key>
+    <string>$(AppIdentifierPrefix)$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.files.downloads.read-write</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-write</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>com.apple.security.network.server</key>
+    <true/>
+</dict>
+</plist>

--- a/App/Support/SDMApp.entitlements
+++ b/App/Support/SDMApp.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>com.apple.application-identifier</key>
+    <string>$(AppIdentifierPrefix)$(PRODUCT_BUNDLE_IDENTIFIER)</string>
     <key>com.apple.security.app-sandbox</key>
     <true/>
     <key>com.apple.security.files.downloads.read-write</key>

--- a/Docs/ThirdPartyLicensing.md
+++ b/Docs/ThirdPartyLicensing.md
@@ -25,6 +25,17 @@ redistribution terms are followed. The repository and app bundle retain all
 four license texts. OpenSSL 3.6.0 has no upstream `NOTICE` file; its complete
 Apache 2.0 license is included.
 
+## Development-only LookInside server
+
+Debug builds link the pinned
+[`LookInsideServer` 0.2.7](https://github.com/LookInsideApp/LookInside-Release/releases/tag/0.2.7)
+binary to support local UI inspection. LookInside is licensed under GPL-3.0.
+The `SDMApp` Release configuration excludes `LookInsideServer*`, and release
+validation must continue to confirm that the framework is absent from the app
+bundle and executable load commands. It is therefore not part of the app's
+distributed third-party notices. Anyone distributing a Debug build must review
+and comply with the upstream license separately.
+
 On macOS, `SDMCore` exports Apple system trust anchors into the app's private
 storage and configures `CURLOPT_CAINFO` with that file. iOS does not expose its
 system root certificates, so the iOS libcurl backend uses the audited

--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,10 @@ let packageSettings = PackageSettings(
 let package = Package(
     name: "SDMDependencies",
     dependencies: [
+        .package(
+            url: "https://github.com/LookInsideApp/LookInside-Release.git",
+            exact: "0.2.7"
+        ),
         .package(path: "Packages/SDMCore"),
     ]
 )

--- a/Project.swift
+++ b/Project.swift
@@ -78,6 +78,7 @@ let project = Project(
                 "TARGETED_DEVICE_FAMILY[sdk=iphone*]": "1,2",
             ], configurations: [
                 .debug(name: "Debug", settings: [
+                    "CODE_SIGN_ENTITLEMENTS[sdk=macosx*]": "App/Support/SDMApp-Debug.entitlements",
                     "CODE_SIGN_IDENTITY[sdk=macosx*]": "Apple Development",
                     "CODE_SIGN_IDENTITY[sdk=iphoneos*]": "Apple Development",
                     "CODE_SIGN_STYLE": "Automatic",

--- a/Project.swift
+++ b/Project.swift
@@ -63,6 +63,7 @@ let project = Project(
             dependencies: [
                 .target(name: "SDMSafariExtension"),
                 .external(name: "SDMCore"),
+                .external(name: "LookInsideServer"),
             ],
             settings: .settings(base: [
                 "ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME": "AccentColor",
@@ -86,6 +87,7 @@ let project = Project(
                     "CODE_SIGN_INJECT_BASE_ENTITLEMENTS[sdk=macosx*]": "NO",
                     "CODE_SIGN_STYLE[sdk=iphoneos*]": "Automatic",
                     "CODE_SIGN_STYLE[sdk=macosx*]": "Manual",
+                    "EXCLUDED_SOURCE_FILE_NAMES": "$(inherited) LookInsideServer*",
                 ]),
             ]),
             metadata: .metadata(tags: [

--- a/README.md
+++ b/README.md
@@ -80,6 +80,22 @@ ports and clean them up automatically.
 See [`Docs/Releasing.md`](Docs/Releasing.md) for the versioning, validation,
 archive, App packaging, GitHub Release, and post-release development workflow.
 
+## LookInside
+
+Debug builds embed the
+[`LookInsideServer`](https://github.com/LookInsideApp/LookInside-Release)
+package so the running macOS or iOS app can be inspected from LookInside.
+Install dependencies, generate the workspace, and run the `SDMApp` scheme in
+the Debug configuration. The app then appears in LookInside's connection list.
+
+The server binary is excluded from Release builds. Keep any future direct
+`LookInsideServer` API calls behind `#if DEBUG` guards.
+
+To resolve private Swift type discriminators, open **Private Discriminator
+Settings…** in LookInside, import module `SDMApp`, and select `App/Sources` as
+its source folder. LookInside indexes filenames locally without uploading the
+source files.
+
 ## Browser extensions
 
 The macOS app provides a **Browser Extensions…** window for setting up Google


### PR DESCRIPTION
## Summary

- add LookInsideServer to Debug builds only
- add separate Debug entitlements for local inspection and background URLSession support
- keep LookInside out of Release and validate the signed application identifier in the release workflow
- document integration and third-party licensing

## Why

Enable LookInside inspection during local development without shipping the inspection server or its server entitlement in Release artifacts.

## Validation

- generated the Tuist workspace
- built macOS and iOS Debug and Release configurations
- verified LookInside is embedded only in Debug
- verified signed Debug and Release entitlements
- passed JavaScript, Python, and Swift test suites