### PR TITLE
Add configurable download locations

### DIFF
--- a/App/Sources/Application/AppStorageKey.swift
+++ b/App/Sources/Application/AppStorageKey.swift
@@ -1,5 +1,7 @@
 enum AppStorageKey {
     static let defaultConnectionCount = "defaultConnectionCount"
+    static let defaultDownloadLocation = "defaultDownloadLocation"
+    static let customDefaultDownloadDirectory = "customDefaultDownloadDirectory"
     static let showsMenuBarIcon = "showsMenuBarIcon"
     static let downloadEngine = "downloadEngine"
 }

--- a/App/Sources/Features/Downloads/DefaultDownloadLocation.swift
+++ b/App/Sources/Features/Downloads/DefaultDownloadLocation.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+enum DefaultDownloadLocation: String, CaseIterable, Identifiable {
+    case appSandbox
+    case downloads
+    case downloadsSDM
+    case custom
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .appSandbox:
+            "App Sandbox"
+        case .downloads:
+            "~/Downloads"
+        case .downloadsSDM:
+            "~/Downloads/SDM"
+        case .custom:
+            "Custom Folder…"
+        }
+    }
+}
+
+struct DefaultDownloadDestinationDirectories: Sendable, Equatable {
+    let appSandbox: URL
+    let downloads: URL
+
+    init(appSandbox: URL, downloads: URL) {
+        self.appSandbox = appSandbox.standardizedFileURL
+        self.downloads = downloads.resolvingSymlinksInPath().standardizedFileURL
+    }
+
+    var downloadsSDM: URL {
+        downloads.appending(path: "SDM", directoryHint: .isDirectory)
+    }
+
+    func directory(for location: DefaultDownloadLocation) -> URL? {
+        switch location {
+        case .appSandbox:
+            appSandbox
+        case .downloads:
+            downloads
+        case .downloadsSDM:
+            downloadsSDM
+        case .custom:
+            nil
+        }
+    }
+}

--- a/App/Sources/Features/Downloads/DefaultDownloadLocation.swift
+++ b/App/Sources/Features/Downloads/DefaultDownloadLocation.swift
@@ -3,7 +3,6 @@ import Foundation
 enum DefaultDownloadLocation: String, CaseIterable, Identifiable {
     case appSandbox
     case downloads
-    case downloadsSDM
     case custom
 
     var id: Self { self }
@@ -33,9 +32,7 @@ enum DefaultDownloadLocation: String, CaseIterable, Identifiable {
             "SDM Documents"
             #endif
         case .downloads:
-            "~/Downloads"
-        case .downloadsSDM:
-            "~/Downloads/SDM"
+            "Downloads Folder"
         case .custom:
             #if os(macOS)
             "Custom Folder…"
@@ -55,18 +52,12 @@ struct DefaultDownloadDestinationDirectories: Sendable, Equatable {
         self.downloads = downloads?.resolvingSymlinksInPath().standardizedFileURL
     }
 
-    var downloadsSDM: URL? {
-        downloads?.appending(path: "SDM", directoryHint: .isDirectory)
-    }
-
     func directory(for location: DefaultDownloadLocation) -> URL? {
         switch location {
         case .appSandbox:
             appSandbox
         case .downloads:
             downloads
-        case .downloadsSDM:
-            downloadsSDM
         case .custom:
             nil
         }

--- a/App/Sources/Features/Downloads/DefaultDownloadLocation.swift
+++ b/App/Sources/Features/Downloads/DefaultDownloadLocation.swift
@@ -8,31 +8,55 @@ enum DefaultDownloadLocation: String, CaseIterable, Identifiable {
 
     var id: Self { self }
 
+    static var availableLocations: [Self] {
+        #if os(macOS)
+        allCases
+        #else
+        [.appSandbox, .custom]
+        #endif
+    }
+
+    static var fallback: Self {
+        #if os(macOS)
+        .downloads
+        #else
+        .appSandbox
+        #endif
+    }
+
     var title: String {
         switch self {
         case .appSandbox:
+            #if os(macOS)
             "App Sandbox"
+            #else
+            "SDM Documents"
+            #endif
         case .downloads:
             "~/Downloads"
         case .downloadsSDM:
             "~/Downloads/SDM"
         case .custom:
+            #if os(macOS)
             "Custom Folder…"
+            #else
+            "External Folder"
+            #endif
         }
     }
 }
 
 struct DefaultDownloadDestinationDirectories: Sendable, Equatable {
     let appSandbox: URL
-    let downloads: URL
+    let downloads: URL?
 
-    init(appSandbox: URL, downloads: URL) {
+    init(appSandbox: URL, downloads: URL? = nil) {
         self.appSandbox = appSandbox.standardizedFileURL
-        self.downloads = downloads.resolvingSymlinksInPath().standardizedFileURL
+        self.downloads = downloads?.resolvingSymlinksInPath().standardizedFileURL
     }
 
-    var downloadsSDM: URL {
-        downloads.appending(path: "SDM", directoryHint: .isDirectory)
+    var downloadsSDM: URL? {
+        downloads?.appending(path: "SDM", directoryHint: .isDirectory)
     }
 
     func directory(for location: DefaultDownloadLocation) -> URL? {

--- a/App/Sources/Features/Downloads/DownloadPresentation.swift
+++ b/App/Sources/Features/Downloads/DownloadPresentation.swift
@@ -159,4 +159,9 @@ struct PresentedDownloadError: Identifiable {
         self.title = title
         message = DownloadService.message(for: error)
     }
+
+    init(title: String, message: String) {
+        self.title = title
+        self.message = message
+    }
 }

--- a/App/Sources/Features/Downloads/DownloadPresentation.swift
+++ b/App/Sources/Features/Downloads/DownloadPresentation.swift
@@ -52,7 +52,7 @@ extension DownloadState {
         case .resume:
             self == .paused
         case .cancel:
-            self != .completed && self != .cancelled
+            self != .completed && self != .cancelled && self != .finalizing
         case .retry:
             self == .failed || self == .cancelled
         case .remove:

--- a/App/Sources/Features/Downloads/DownloadService.swift
+++ b/App/Sources/Features/Downloads/DownloadService.swift
@@ -102,10 +102,7 @@ final class DownloadService {
                 )
             }
             let defaultDestinationDirectories = DefaultDownloadDestinationDirectories(
-                appSandbox: storagePaths.rootDirectory.appending(
-                    path: "Downloads",
-                    directoryHint: .isDirectory
-                ),
+                appSandbox: downloadsDirectory,
                 downloads: downloadsDirectory
             )
             #else
@@ -151,7 +148,8 @@ final class DownloadService {
                     fileManager: fileManager
                 )
                 try? destinationBookmarks?.release(
-                    owner: defaultDestinationBookmarkOwner
+                    owner: defaultDestinationBookmarkOwner,
+                    retainBookmarkWhenUnowned: true
                 )
                 userDefaults.set(
                     defaultDownloadLocation.rawValue,
@@ -238,7 +236,8 @@ final class DownloadService {
             )
         } else {
             try destinationBookmarks?.release(
-                owner: Self.defaultDestinationBookmarkOwner
+                owner: Self.defaultDestinationBookmarkOwner,
+                retainBookmarkWhenUnowned: true
             )
         }
         userDefaults.set(location.rawValue, forKey: AppStorageKey.defaultDownloadLocation)
@@ -525,14 +524,18 @@ final class DownloadService {
         }
         let authorizedDirectory = try destinationBookmarks.authorize(
             customDirectory,
-            owner: bookmarkOwner
+            owner: bookmarkOwner,
+            retainBookmarkWhenUnowned: true
         )
         var isDirectory: ObjCBool = false
         guard fileManager.fileExists(
             atPath: authorizedDirectory.path,
             isDirectory: &isDirectory
         ), isDirectory.boolValue else {
-            try? destinationBookmarks.release(owner: bookmarkOwner)
+            try? destinationBookmarks.release(
+                owner: bookmarkOwner,
+                retainBookmarkWhenUnowned: true
+            )
             throw ServiceError.unavailable(
                 "The selected custom download folder is no longer available."
             )

--- a/App/Sources/Features/Downloads/DownloadService.swift
+++ b/App/Sources/Features/Downloads/DownloadService.swift
@@ -13,13 +13,16 @@ final class DownloadService {
     private(set) var logsByDownloadID: [DownloadID: [DownloadDiagnosticEvent]] = [:]
     private(set) var engineDescriptors: [DownloadEngineDescriptor] = []
     private(set) var selectedEngine: DownloadEngineKind
+    private(set) var defaultDestinationDirectory: URL
+    private(set) var defaultDownloadLocation: DefaultDownloadLocation
 
-    let defaultDestinationDirectory: URL
     let databaseURL: URL?
     let initializationError: String?
 
     private let manager: DownloadManager?
     private let destinationBookmarks: DestinationBookmarkStore?
+    private let defaultDestinationDirectories: DefaultDownloadDestinationDirectories?
+    private let userDefaults: UserDefaults
     @ObservationIgnored
     nonisolated(unsafe) private var observationTask: Task<Void, Never>?
     @ObservationIgnored private var previousSnapshots: [DownloadID: DownloadSnapshot] = [:]
@@ -27,12 +30,18 @@ final class DownloadService {
     init(
         configuration: DownloadManagerConfiguration,
         destinationDirectory: URL = FileManager.default.temporaryDirectory,
-        destinationBookmarks: DestinationBookmarkStore? = nil
+        destinationBookmarks: DestinationBookmarkStore? = nil,
+        defaultDownloadLocation: DefaultDownloadLocation = .custom,
+        defaultDestinationDirectories: DefaultDownloadDestinationDirectories? = nil,
+        userDefaults: UserDefaults = .standard
     ) throws {
         manager = try DownloadManager(configuration: configuration)
         selectedEngine = configuration.defaultEngine
         self.destinationBookmarks = destinationBookmarks
         defaultDestinationDirectory = destinationDirectory
+        self.defaultDownloadLocation = defaultDownloadLocation
+        self.defaultDestinationDirectories = defaultDestinationDirectories
+        self.userDefaults = userDefaults
         databaseURL = configuration.databaseURL
         initializationError = nil
         snapshots = []
@@ -46,12 +55,18 @@ final class DownloadService {
         destinationDirectory: URL,
         databaseURL: URL?,
         destinationBookmarks: DestinationBookmarkStore?,
+        defaultDownloadLocation: DefaultDownloadLocation,
+        defaultDestinationDirectories: DefaultDownloadDestinationDirectories?,
+        userDefaults: UserDefaults,
         initializationError: String?,
         snapshots: [DownloadSnapshot]
     ) {
         self.manager = manager
         self.destinationBookmarks = destinationBookmarks
         defaultDestinationDirectory = destinationDirectory
+        self.defaultDownloadLocation = defaultDownloadLocation
+        self.defaultDestinationDirectories = defaultDestinationDirectories
+        self.userDefaults = userDefaults
         self.databaseURL = databaseURL
         self.initializationError = initializationError
         selectedEngine = .libcurl
@@ -61,35 +76,80 @@ final class DownloadService {
         ingest(snapshots)
     }
 
-    static func live(fileManager: FileManager = .default) -> DownloadService {
+    static func live(
+        fileManager: FileManager = .default,
+        userDefaults: UserDefaults = .standard
+    ) -> DownloadService {
         do {
             let storagePaths = try AppStoragePaths.live(fileManager: fileManager)
             let destinationBookmarks = try? DestinationBookmarkStore(
                 storeURL: storagePaths.destinationBookmarksURL
             )
             #if os(macOS)
-            let destinationSearchPath: FileManager.SearchPathDirectory = .downloadsDirectory
-            #else
-            let destinationSearchPath: FileManager.SearchPathDirectory = .documentDirectory
-            #endif
-            guard let destinationDirectory = fileManager.urls(
-                for: destinationSearchPath,
+            guard let downloadsDirectory = fileManager.urls(
+                for: .downloadsDirectory,
                 in: .userDomainMask
             ).first else {
                 throw ServiceError.unavailable(
                     "The Downloads directory could not be located."
                 )
             }
+            let defaultDestinationDirectories = DefaultDownloadDestinationDirectories(
+                appSandbox: storagePaths.rootDirectory.appending(
+                    path: "Downloads",
+                    directoryHint: .isDirectory
+                ),
+                downloads: downloadsDirectory
+            )
+            var defaultDownloadLocation = storedDefaultDownloadLocation(in: userDefaults)
+            let destinationDirectory: URL
+            do {
+                destinationDirectory = try resolveDefaultDestination(
+                    location: defaultDownloadLocation,
+                    customDirectory: storedCustomDefaultDestination(in: userDefaults),
+                    directories: defaultDestinationDirectories,
+                    destinationBookmarks: destinationBookmarks,
+                    fileManager: fileManager
+                )
+            } catch {
+                defaultDownloadLocation = .downloads
+                destinationDirectory = try resolveDefaultDestination(
+                    location: defaultDownloadLocation,
+                    customDirectory: nil,
+                    directories: defaultDestinationDirectories,
+                    destinationBookmarks: destinationBookmarks,
+                    fileManager: fileManager
+                )
+                userDefaults.set(
+                    defaultDownloadLocation.rawValue,
+                    forKey: AppStorageKey.defaultDownloadLocation
+                )
+            }
+            #else
+            guard let destinationDirectory = fileManager.urls(
+                for: .documentDirectory,
+                in: .userDomainMask
+            ).first else {
+                throw ServiceError.unavailable(
+                    "The Documents directory could not be located."
+                )
+            }
+            let defaultDownloadLocation = DefaultDownloadLocation.appSandbox
+            let defaultDestinationDirectories: DefaultDownloadDestinationDirectories? = nil
+            #endif
 
             return try DownloadService(
                 configuration: storagePaths.managerConfiguration(
-                    defaultEngine: storedEngine,
+                    defaultEngine: storedEngine(in: userDefaults),
                     urlSessionIdentifier: Bundle.main.bundleIdentifier.map {
                         "\($0).urlsession-downloads"
                     }
                 ),
                 destinationDirectory: destinationDirectory,
-                destinationBookmarks: destinationBookmarks
+                destinationBookmarks: destinationBookmarks,
+                defaultDownloadLocation: defaultDownloadLocation,
+                defaultDestinationDirectories: defaultDestinationDirectories,
+                userDefaults: userDefaults
             )
         } catch {
             return DownloadService(
@@ -97,6 +157,9 @@ final class DownloadService {
                 destinationDirectory: fileManager.temporaryDirectory,
                 databaseURL: nil,
                 destinationBookmarks: nil,
+                defaultDownloadLocation: .appSandbox,
+                defaultDestinationDirectories: nil,
+                userDefaults: userDefaults,
                 initializationError: Self.message(for: error),
                 snapshots: []
             )
@@ -112,9 +175,46 @@ final class DownloadService {
             destinationDirectory: destinationDirectory,
             databaseURL: nil,
             destinationBookmarks: nil,
+            defaultDownloadLocation: .appSandbox,
+            defaultDestinationDirectories: nil,
+            userDefaults: .standard,
             initializationError: nil,
             snapshots: snapshots
         )
+    }
+
+    var hasStoredCustomDefaultDestination: Bool {
+        Self.storedCustomDefaultDestination(in: userDefaults) != nil
+    }
+
+    func selectDefaultDestination(
+        _ location: DefaultDownloadLocation,
+        customDirectory: URL? = nil,
+        fileManager: FileManager = .default
+    ) throws {
+        guard let defaultDestinationDirectories else {
+            throw ServiceError.unavailable(
+                "Default download folder settings are unavailable on this platform."
+            )
+        }
+        let storedCustomDirectory = Self.storedCustomDefaultDestination(in: userDefaults)
+        let resolvedDirectory = try Self.resolveDefaultDestination(
+            location: location,
+            customDirectory: customDirectory ?? storedCustomDirectory,
+            directories: defaultDestinationDirectories,
+            destinationBookmarks: destinationBookmarks,
+            fileManager: fileManager
+        )
+
+        if location == .custom {
+            userDefaults.set(
+                resolvedDirectory.path(percentEncoded: false),
+                forKey: AppStorageKey.customDefaultDownloadDirectory
+            )
+        }
+        userDefaults.set(location.rawValue, forKey: AppStorageKey.defaultDownloadLocation)
+        defaultDownloadLocation = location
+        defaultDestinationDirectory = resolvedDirectory
     }
 
     func enqueue(
@@ -312,10 +412,64 @@ final class DownloadService {
         }
     }
 
-
-    private static var storedEngine: DownloadEngineKind {
-        UserDefaults.standard.string(forKey: AppStorageKey.downloadEngine)
+    private static func storedEngine(in userDefaults: UserDefaults) -> DownloadEngineKind {
+        userDefaults.string(forKey: AppStorageKey.downloadEngine)
             .flatMap(DownloadEngineKind.init(rawValue:))
             ?? .libcurl
+    }
+
+    private static func storedDefaultDownloadLocation(
+        in userDefaults: UserDefaults
+    ) -> DefaultDownloadLocation {
+        userDefaults.string(forKey: AppStorageKey.defaultDownloadLocation)
+            .flatMap(DefaultDownloadLocation.init(rawValue:))
+            ?? .downloads
+    }
+
+    private static func storedCustomDefaultDestination(
+        in userDefaults: UserDefaults
+    ) -> URL? {
+        guard let path = userDefaults.string(
+            forKey: AppStorageKey.customDefaultDownloadDirectory
+        ), !path.isEmpty else {
+            return nil
+        }
+        return URL(filePath: path, directoryHint: .isDirectory)
+    }
+
+    private static func resolveDefaultDestination(
+        location: DefaultDownloadLocation,
+        customDirectory: URL?,
+        directories: DefaultDownloadDestinationDirectories,
+        destinationBookmarks: DestinationBookmarkStore?,
+        fileManager: FileManager
+    ) throws -> URL {
+        if let directory = directories.directory(for: location) {
+            try fileManager.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true
+            )
+            return directory.standardizedFileURL
+        }
+
+        guard let customDirectory else {
+            throw ServiceError.unavailable("Choose a custom download folder first.")
+        }
+        guard let destinationBookmarks else {
+            throw ServiceError.unavailable(
+                "Persistent access to custom download folders is unavailable."
+            )
+        }
+        let authorizedDirectory = try destinationBookmarks.authorize(customDirectory)
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(
+            atPath: authorizedDirectory.path,
+            isDirectory: &isDirectory
+        ), isDirectory.boolValue else {
+            throw ServiceError.unavailable(
+                "The selected custom download folder is no longer available."
+            )
+        }
+        return authorizedDirectory.standardizedFileURL
     }
 }

--- a/App/Sources/Features/Downloads/DownloadService.swift
+++ b/App/Sources/Features/Downloads/DownloadService.swift
@@ -7,6 +7,8 @@ import SDMCore
 @Observable
 @MainActor
 final class DownloadService {
+    private static let defaultDestinationBookmarkOwner = "default-destination"
+
     private(set) var snapshots: [DownloadSnapshot]
     private(set) var isLoadingHistory: Bool
     private(set) var commandInFlightIDs: Set<DownloadID> = []
@@ -18,6 +20,7 @@ final class DownloadService {
 
     let databaseURL: URL?
     let initializationError: String?
+    let defaultDestinationRecoveryMessage: String?
 
     private let manager: DownloadManager?
     private let destinationBookmarks: DestinationBookmarkStore?
@@ -33,6 +36,7 @@ final class DownloadService {
         destinationBookmarks: DestinationBookmarkStore? = nil,
         defaultDownloadLocation: DefaultDownloadLocation = .custom,
         defaultDestinationDirectories: DefaultDownloadDestinationDirectories? = nil,
+        defaultDestinationRecoveryMessage: String? = nil,
         userDefaults: UserDefaults = .standard
     ) throws {
         manager = try DownloadManager(configuration: configuration)
@@ -41,6 +45,7 @@ final class DownloadService {
         defaultDestinationDirectory = destinationDirectory
         self.defaultDownloadLocation = defaultDownloadLocation
         self.defaultDestinationDirectories = defaultDestinationDirectories
+        self.defaultDestinationRecoveryMessage = defaultDestinationRecoveryMessage
         self.userDefaults = userDefaults
         databaseURL = configuration.databaseURL
         initializationError = nil
@@ -57,6 +62,7 @@ final class DownloadService {
         destinationBookmarks: DestinationBookmarkStore?,
         defaultDownloadLocation: DefaultDownloadLocation,
         defaultDestinationDirectories: DefaultDownloadDestinationDirectories?,
+        defaultDestinationRecoveryMessage: String?,
         userDefaults: UserDefaults,
         initializationError: String?,
         snapshots: [DownloadSnapshot]
@@ -66,6 +72,7 @@ final class DownloadService {
         defaultDestinationDirectory = destinationDirectory
         self.defaultDownloadLocation = defaultDownloadLocation
         self.defaultDestinationDirectories = defaultDestinationDirectories
+        self.defaultDestinationRecoveryMessage = defaultDestinationRecoveryMessage
         self.userDefaults = userDefaults
         self.databaseURL = databaseURL
         self.initializationError = initializationError
@@ -101,32 +108,8 @@ final class DownloadService {
                 ),
                 downloads: downloadsDirectory
             )
-            var defaultDownloadLocation = storedDefaultDownloadLocation(in: userDefaults)
-            let destinationDirectory: URL
-            do {
-                destinationDirectory = try resolveDefaultDestination(
-                    location: defaultDownloadLocation,
-                    customDirectory: storedCustomDefaultDestination(in: userDefaults),
-                    directories: defaultDestinationDirectories,
-                    destinationBookmarks: destinationBookmarks,
-                    fileManager: fileManager
-                )
-            } catch {
-                defaultDownloadLocation = .downloads
-                destinationDirectory = try resolveDefaultDestination(
-                    location: defaultDownloadLocation,
-                    customDirectory: nil,
-                    directories: defaultDestinationDirectories,
-                    destinationBookmarks: destinationBookmarks,
-                    fileManager: fileManager
-                )
-                userDefaults.set(
-                    defaultDownloadLocation.rawValue,
-                    forKey: AppStorageKey.defaultDownloadLocation
-                )
-            }
             #else
-            guard let destinationDirectory = fileManager.urls(
+            guard let documentsDirectory = fileManager.urls(
                 for: .documentDirectory,
                 in: .userDomainMask
             ).first else {
@@ -134,9 +117,47 @@ final class DownloadService {
                     "The Documents directory could not be located."
                 )
             }
-            let defaultDownloadLocation = DefaultDownloadLocation.appSandbox
-            let defaultDestinationDirectories: DefaultDownloadDestinationDirectories? = nil
+            let defaultDestinationDirectories = DefaultDownloadDestinationDirectories(
+                appSandbox: documentsDirectory
+            )
             #endif
+
+            var defaultDownloadLocation = storedDefaultDownloadLocation(in: userDefaults)
+            var defaultDestinationRecoveryMessage: String?
+            let destinationDirectory: URL
+            do {
+                destinationDirectory = try resolveDefaultDestination(
+                    location: defaultDownloadLocation,
+                    customDirectory: storedCustomDefaultDestination(in: userDefaults),
+                    directories: defaultDestinationDirectories,
+                    destinationBookmarks: destinationBookmarks,
+                    bookmarkOwner: defaultDestinationBookmarkOwner,
+                    fileManager: fileManager
+                )
+            } catch {
+                if defaultDownloadLocation == .custom {
+                    defaultDestinationRecoveryMessage =
+                        "The previously selected external folder is unavailable. "
+                        + "SDM is using \(DefaultDownloadLocation.fallback.title). "
+                        + "Choose the external folder again in Settings."
+                }
+                defaultDownloadLocation = .fallback
+                destinationDirectory = try resolveDefaultDestination(
+                    location: defaultDownloadLocation,
+                    customDirectory: nil,
+                    directories: defaultDestinationDirectories,
+                    destinationBookmarks: destinationBookmarks,
+                    bookmarkOwner: defaultDestinationBookmarkOwner,
+                    fileManager: fileManager
+                )
+                try? destinationBookmarks?.release(
+                    owner: defaultDestinationBookmarkOwner
+                )
+                userDefaults.set(
+                    defaultDownloadLocation.rawValue,
+                    forKey: AppStorageKey.defaultDownloadLocation
+                )
+            }
 
             return try DownloadService(
                 configuration: storagePaths.managerConfiguration(
@@ -149,6 +170,7 @@ final class DownloadService {
                 destinationBookmarks: destinationBookmarks,
                 defaultDownloadLocation: defaultDownloadLocation,
                 defaultDestinationDirectories: defaultDestinationDirectories,
+                defaultDestinationRecoveryMessage: defaultDestinationRecoveryMessage,
                 userDefaults: userDefaults
             )
         } catch {
@@ -159,6 +181,7 @@ final class DownloadService {
                 destinationBookmarks: nil,
                 defaultDownloadLocation: .appSandbox,
                 defaultDestinationDirectories: nil,
+                defaultDestinationRecoveryMessage: nil,
                 userDefaults: userDefaults,
                 initializationError: Self.message(for: error),
                 snapshots: []
@@ -177,6 +200,7 @@ final class DownloadService {
             destinationBookmarks: nil,
             defaultDownloadLocation: .appSandbox,
             defaultDestinationDirectories: nil,
+            defaultDestinationRecoveryMessage: nil,
             userDefaults: .standard,
             initializationError: nil,
             snapshots: snapshots
@@ -203,6 +227,7 @@ final class DownloadService {
             customDirectory: customDirectory ?? storedCustomDirectory,
             directories: defaultDestinationDirectories,
             destinationBookmarks: destinationBookmarks,
+            bookmarkOwner: Self.defaultDestinationBookmarkOwner,
             fileManager: fileManager
         )
 
@@ -210,6 +235,10 @@ final class DownloadService {
             userDefaults.set(
                 resolvedDirectory.path(percentEncoded: false),
                 forKey: AppStorageKey.customDefaultDownloadDirectory
+            )
+        } else {
+            try destinationBookmarks?.release(
+                owner: Self.defaultDestinationBookmarkOwner
             )
         }
         userDefaults.set(location.rawValue, forKey: AppStorageKey.defaultDownloadLocation)
@@ -225,27 +254,40 @@ final class DownloadService {
     ) async throws -> DownloadID {
         let manager = try requiredManager()
         let requestedDestination = destinationDirectory ?? defaultDestinationDirectory
+        let requestID = DownloadID()
+        let bookmarkOwner = Self.downloadBookmarkOwner(for: requestID)
+        let usesDefaultDestination = requestedDestination.standardizedFileURL ==
+            defaultDestinationDirectory.standardizedFileURL
+        let requiresBookmark = !usesDefaultDestination || defaultDownloadLocation == .custom
         let authorizedDestination: URL
-        if requestedDestination.standardizedFileURL !=
-            defaultDestinationDirectory.standardizedFileURL {
+        if requiresBookmark {
             guard let destinationBookmarks else {
                 throw ServiceError.unavailable(
                     "Persistent access to custom download folders is unavailable."
                 )
             }
             authorizedDestination = try destinationBookmarks.authorize(
-                requestedDestination
+                requestedDestination,
+                owner: bookmarkOwner
             )
         } else {
             authorizedDestination = requestedDestination
         }
         let request = DownloadRequest(
+            id: requestID,
             url: url,
             destinationDirectory: authorizedDestination,
             filename: suggestedFilename,
             connectionLimit: connectionCount
         )
-        return try await manager.enqueue(request)
+        do {
+            return try await manager.enqueue(request)
+        } catch {
+            if requiresBookmark {
+                try? destinationBookmarks?.release(owner: bookmarkOwner)
+            }
+            throw error
+        }
     }
 
     var selectedEngineDescriptor: DownloadEngineDescriptor {
@@ -287,6 +329,9 @@ final class DownloadService {
             try await manager.retry(id)
         case .remove:
             try await manager.remove(id)
+            try? destinationBookmarks?.release(
+                owner: Self.downloadBookmarkOwner(for: id)
+            )
         }
         return true
     }
@@ -334,6 +379,9 @@ final class DownloadService {
         }
         try FileManager.default.removeItem(at: destinationURL)
         try await manager.remove(id)
+        try destinationBookmarks?.release(
+            owner: Self.downloadBookmarkOwner(for: id)
+        )
     }
 
     func shutdown() async {
@@ -418,12 +466,20 @@ final class DownloadService {
             ?? .libcurl
     }
 
+    private static func downloadBookmarkOwner(for id: DownloadID) -> String {
+        "download:\(id.description)"
+    }
+
     private static func storedDefaultDownloadLocation(
         in userDefaults: UserDefaults
     ) -> DefaultDownloadLocation {
-        userDefaults.string(forKey: AppStorageKey.defaultDownloadLocation)
-            .flatMap(DefaultDownloadLocation.init(rawValue:))
-            ?? .downloads
+        guard let location = userDefaults.string(
+            forKey: AppStorageKey.defaultDownloadLocation
+        ).flatMap(DefaultDownloadLocation.init(rawValue:)),
+            DefaultDownloadLocation.availableLocations.contains(location) else {
+            return .fallback
+        }
+        return location
     }
 
     private static func storedCustomDefaultDestination(
@@ -442,6 +498,7 @@ final class DownloadService {
         customDirectory: URL?,
         directories: DefaultDownloadDestinationDirectories,
         destinationBookmarks: DestinationBookmarkStore?,
+        bookmarkOwner: String,
         fileManager: FileManager
     ) throws -> URL {
         if let directory = directories.directory(for: location) {
@@ -452,6 +509,12 @@ final class DownloadService {
             return directory.standardizedFileURL
         }
 
+        guard location == .custom else {
+            throw ServiceError.unavailable(
+                "The selected default download folder is unavailable on this platform."
+            )
+        }
+
         guard let customDirectory else {
             throw ServiceError.unavailable("Choose a custom download folder first.")
         }
@@ -460,12 +523,16 @@ final class DownloadService {
                 "Persistent access to custom download folders is unavailable."
             )
         }
-        let authorizedDirectory = try destinationBookmarks.authorize(customDirectory)
+        let authorizedDirectory = try destinationBookmarks.authorize(
+            customDirectory,
+            owner: bookmarkOwner
+        )
         var isDirectory: ObjCBool = false
         guard fileManager.fileExists(
             atPath: authorizedDirectory.path,
             isDirectory: &isDirectory
         ), isDirectory.boolValue else {
+            try? destinationBookmarks.release(owner: bookmarkOwner)
             throw ServiceError.unavailable(
                 "The selected custom download folder is no longer available."
             )

--- a/App/Sources/Features/Downloads/DownloadService.swift
+++ b/App/Sources/Features/Downloads/DownloadService.swift
@@ -476,6 +476,10 @@ final class DownloadService {
             forKey: AppStorageKey.defaultDownloadLocation
         ).flatMap(DefaultDownloadLocation.init(rawValue:)),
             DefaultDownloadLocation.availableLocations.contains(location) else {
+            userDefaults.set(
+                DefaultDownloadLocation.fallback.rawValue,
+                forKey: AppStorageKey.defaultDownloadLocation
+            )
             return .fallback
         }
         return location

--- a/App/Sources/Features/Downloads/Mobile/MobileContentView.swift
+++ b/App/Sources/Features/Downloads/Mobile/MobileContentView.swift
@@ -13,6 +13,7 @@ struct MobileContentView: View {
     @State private var showsNewDownload = false
     @State private var showsSettings = false
     @State private var presentedError: PresentedDownloadError?
+    @State private var didPresentDestinationRecovery = false
 
     private var selectedFilter: DownloadFilter {
         selection ?? .all
@@ -179,6 +180,9 @@ struct MobileContentView: View {
             selectedDownloadIDs.formIntersection(availableIDs)
         }
         .onOpenURL(perform: handleExternalURL)
+        .task {
+            presentDestinationRecoveryIfNeeded()
+        }
     }
 
     private var emptyTitle: String {
@@ -193,6 +197,16 @@ struct MobileContentView: View {
 
     private func presentNewDownload() {
         showsNewDownload = true
+    }
+
+    private func presentDestinationRecoveryIfNeeded() {
+        guard !didPresentDestinationRecovery,
+              let message = service.defaultDestinationRecoveryMessage else { return }
+        didPresentDestinationRecovery = true
+        presentedError = PresentedDownloadError(
+            title: "External Folder Unavailable",
+            message: message
+        )
     }
 
     private func perform(_ command: DownloadCommand, on id: DownloadID) {

--- a/App/Sources/Features/Settings/MacSettingsFormContent.swift
+++ b/App/Sources/Features/Settings/MacSettingsFormContent.swift
@@ -52,7 +52,7 @@ struct MacSettingsFormContent: View {
 
         Section {
             Picker("Default save location", selection: $defaultDownloadLocation) {
-                ForEach(DefaultDownloadLocation.allCases) { location in
+                ForEach(DefaultDownloadLocation.availableLocations) { location in
                     Text(location.title)
                         .tag(location)
                 }

--- a/App/Sources/Features/Settings/MacSettingsFormContent.swift
+++ b/App/Sources/Features/Settings/MacSettingsFormContent.swift
@@ -4,12 +4,15 @@ import SwiftUI
 
 struct MacSettingsFormContent: View {
     @Binding var defaultConnectionCount: Int
+    @Binding var defaultDownloadLocation: DefaultDownloadLocation
     @Binding var showsMenuBarIcon: Bool
     @Binding var selectedEngine: String
     let engineDescriptors: [DownloadEngineDescriptor]
     let selectedDescriptor: DownloadEngineDescriptor?
     let safariExtensionIsEnabled: Bool?
     let databaseURL: URL?
+    let defaultDestinationDirectory: URL
+    let chooseCustomDefaultDestination: () -> Void
     let openSafariSettings: () -> Void
     let showBrowserExtensions: () -> Void
     let showLegalNotices: () -> Void
@@ -48,6 +51,25 @@ struct MacSettingsFormContent: View {
         }
 
         Section {
+            Picker("Default save location", selection: $defaultDownloadLocation) {
+                ForEach(DefaultDownloadLocation.allCases) { location in
+                    Text(location.title)
+                        .tag(location)
+                }
+            }
+            .pickerStyle(.menu)
+
+            LabeledContent("Current folder") {
+                Text(defaultDestinationPath)
+                    .lineLimit(2)
+                    .truncationMode(.middle)
+                    .textSelection(.enabled)
+            }
+
+            if defaultDownloadLocation == .custom {
+                Button("Choose Custom Folder…", action: chooseCustomDefaultDestination)
+            }
+
             Stepper(
                 "Default connections: \(defaultConnectionCount)",
                 value: $defaultConnectionCount,
@@ -57,8 +79,11 @@ struct MacSettingsFormContent: View {
         } header: {
             Text("Downloads")
         } footer: {
-            if selectedDescriptor?.supports(.multiConnectionTransfers) == false {
-                Text("URLSession manages connections internally and uses one connection per download.")
+            VStack(alignment: .leading) {
+                Text("New downloads use this folder by default. You can still choose a different folder for an individual download.")
+                if selectedDescriptor?.supports(.multiConnectionTransfers) == false {
+                    Text("URLSession manages connections internally and uses one connection per download.")
+                }
             }
         }
 
@@ -98,6 +123,15 @@ struct MacSettingsFormContent: View {
                 .foregroundStyle(.secondary)
 
             Button("View Third-Party Licenses", action: showLegalNotices)
+        }
+    }
+
+    private var defaultDestinationPath: String {
+        switch defaultDownloadLocation {
+        case .downloads, .downloadsSDM:
+            defaultDownloadLocation.title
+        case .appSandbox, .custom:
+            defaultDestinationDirectory.path(percentEncoded: false)
         }
     }
 

--- a/App/Sources/Features/Settings/MacSettingsFormContent.swift
+++ b/App/Sources/Features/Settings/MacSettingsFormContent.swift
@@ -127,12 +127,7 @@ struct MacSettingsFormContent: View {
     }
 
     private var defaultDestinationPath: String {
-        switch defaultDownloadLocation {
-        case .downloads, .downloadsSDM:
-            defaultDownloadLocation.title
-        case .appSandbox, .custom:
-            defaultDestinationDirectory.path(percentEncoded: false)
-        }
+        defaultDestinationDirectory.path(percentEncoded: false)
     }
 
     private var extensionStatusTitle: String {

--- a/App/Sources/Features/Settings/MobileSettingsFormContent.swift
+++ b/App/Sources/Features/Settings/MobileSettingsFormContent.swift
@@ -4,11 +4,14 @@ import SwiftUI
 
 struct MobileSettingsFormContent: View {
     @Binding var defaultConnectionCount: Int
+    @Binding var defaultDownloadLocation: DefaultDownloadLocation
     @Binding var selectedEngine: String
     let engineDescriptors: [DownloadEngineDescriptor]
     let selectedDescriptor: DownloadEngineDescriptor?
     let safariExtensionIsEnabled: Bool?
     let databaseURL: URL?
+    let defaultDestinationDirectory: URL
+    let chooseCustomDefaultDestination: () -> Void
     let openSafariSettings: () -> Void
 
     var body: some View {
@@ -31,6 +34,28 @@ struct MobileSettingsFormContent: View {
         }
 
         Section {
+            Picker("Default save location", selection: $defaultDownloadLocation) {
+                ForEach(DefaultDownloadLocation.availableLocations) { location in
+                    Text(location.title)
+                        .tag(location)
+                }
+            }
+            .pickerStyle(.navigationLink)
+
+            LabeledContent("Current folder") {
+                Text(currentFolderName)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+
+            if defaultDownloadLocation == .custom {
+                Button(
+                    "Choose External Folder…",
+                    systemImage: "folder",
+                    action: chooseCustomDefaultDestination
+                )
+            }
+
             Stepper(value: $defaultConnectionCount, in: 1 ... 16) {
                 LabeledContent("Default connections") {
                     Text(defaultConnectionCount, format: .number)
@@ -40,10 +65,13 @@ struct MobileSettingsFormContent: View {
         } header: {
             Text("Downloads")
         } footer: {
-            if selectedDescriptor?.supports(.multiConnectionTransfers) == false {
-                Text("URLSession manages connections internally and uses one connection per download.")
-            } else {
-                Text("New downloads use this many connections when the server supports segmented transfers.")
+            VStack(alignment: .leading) {
+                Text("Choose any folder available in Files, including iCloud Drive and supported third-party providers.")
+                if selectedDescriptor?.supports(.multiConnectionTransfers) == false {
+                    Text("URLSession manages connections internally and uses one connection per download.")
+                } else {
+                    Text("New downloads use this many connections when the server supports segmented transfers.")
+                }
             }
         }
 
@@ -97,6 +125,14 @@ struct MobileSettingsFormContent: View {
 
     private var extensionStatusStyle: Color {
         safariExtensionIsEnabled == true ? .green : .secondary
+    }
+
+    private var currentFolderName: String {
+        if defaultDownloadLocation == .appSandbox {
+            DefaultDownloadLocation.appSandbox.title
+        } else {
+            defaultDestinationDirectory.lastPathComponent
+        }
     }
 }
 #endif

--- a/App/Sources/Features/Settings/SettingsView.swift
+++ b/App/Sources/Features/Settings/SettingsView.swift
@@ -1,5 +1,6 @@
 import SDMCore
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct SettingsView: View {
     #if os(macOS)
@@ -9,6 +10,9 @@ struct SettingsView: View {
     @AppStorage(AppStorageKey.downloadEngine) private var selectedEngine = DownloadEngineKind.libcurl.rawValue
     #if os(macOS)
     @AppStorage(AppStorageKey.showsMenuBarIcon) private var showsMenuBarIcon = true
+    @State private var defaultDownloadLocation: DefaultDownloadLocation
+    @State private var locationBeforeCustomPicker: DefaultDownloadLocation?
+    @State private var showsCustomDestinationPicker = false
     #endif
     @State private var safariExtensionIsEnabled: Bool?
     @State private var presentedError: PresentedDownloadError?
@@ -16,6 +20,13 @@ struct SettingsView: View {
     @State private var showsLegalNotices = false
     #endif
     @Bindable var service: DownloadService
+
+    init(service: DownloadService) {
+        self.service = service
+        #if os(macOS)
+        _defaultDownloadLocation = State(initialValue: service.defaultDownloadLocation)
+        #endif
+    }
 
     var body: some View {
         Form {
@@ -32,12 +43,15 @@ struct SettingsView: View {
             #else
             MacSettingsFormContent(
                 defaultConnectionCount: $defaultConnectionCount,
+                defaultDownloadLocation: $defaultDownloadLocation,
                 showsMenuBarIcon: $showsMenuBarIcon,
                 selectedEngine: $selectedEngine,
                 engineDescriptors: service.engineDescriptors,
                 selectedDescriptor: selectedDescriptor,
                 safariExtensionIsEnabled: safariExtensionIsEnabled,
                 databaseURL: service.databaseURL,
+                defaultDestinationDirectory: service.defaultDestinationDirectory,
+                chooseCustomDefaultDestination: presentCustomDestinationPicker,
                 openSafariSettings: SafariExtensionSupport.showPreferences,
                 showBrowserExtensions: showBrowserExtensions,
                 showLegalNotices: { showsLegalNotices = true }
@@ -70,6 +84,21 @@ struct SettingsView: View {
         .onChange(of: selectedEngine) { _, _ in
             applyEngineSelection()
         }
+        #if os(macOS)
+        .onChange(of: defaultDownloadLocation) { oldLocation, newLocation in
+            applyDefaultDownloadLocation(
+                from: oldLocation,
+                to: newLocation
+            )
+        }
+        .fileImporter(
+            isPresented: $showsCustomDestinationPicker,
+            allowedContentTypes: [.folder],
+            allowsMultipleSelection: false,
+            onCompletion: applyCustomDestination,
+            onCancellation: cancelCustomDestinationPicker
+        )
+        #endif
         .alert(item: $presentedError) { error in
             Alert(
                 title: Text(error.title),
@@ -121,6 +150,63 @@ struct SettingsView: View {
     #if os(macOS)
     private func showBrowserExtensions() {
         openWindow(id: AppWindowID.browsers)
+    }
+
+    private func applyDefaultDownloadLocation(
+        from oldLocation: DefaultDownloadLocation,
+        to newLocation: DefaultDownloadLocation
+    ) {
+        guard newLocation != service.defaultDownloadLocation else { return }
+        if newLocation == .custom, !service.hasStoredCustomDefaultDestination {
+            locationBeforeCustomPicker = oldLocation
+            showsCustomDestinationPicker = true
+            return
+        }
+
+        do {
+            try service.selectDefaultDestination(newLocation)
+        } catch {
+            defaultDownloadLocation = service.defaultDownloadLocation
+            presentedError = PresentedDownloadError(
+                title: "Could Not Change Default Save Location",
+                error: error
+            )
+        }
+    }
+
+    private func presentCustomDestinationPicker() {
+        locationBeforeCustomPicker = service.defaultDownloadLocation
+        showsCustomDestinationPicker = true
+    }
+
+    private func applyCustomDestination(_ result: Result<[URL], Error>) {
+        do {
+            guard let directory = try result.get().first else {
+                cancelCustomDestinationPicker()
+                return
+            }
+            try service.selectDefaultDestination(
+                .custom,
+                customDirectory: directory
+            )
+            defaultDownloadLocation = .custom
+            locationBeforeCustomPicker = nil
+        } catch {
+            defaultDownloadLocation = locationBeforeCustomPicker
+                ?? service.defaultDownloadLocation
+            locationBeforeCustomPicker = nil
+            guard (error as? CocoaError)?.code != .userCancelled else { return }
+            presentedError = PresentedDownloadError(
+                title: "Could Not Choose Default Save Location",
+                error: error
+            )
+        }
+    }
+
+    private func cancelCustomDestinationPicker() {
+        defaultDownloadLocation = locationBeforeCustomPicker
+            ?? service.defaultDownloadLocation
+        locationBeforeCustomPicker = nil
     }
     #endif
 }

--- a/App/Sources/Features/Settings/SettingsView.swift
+++ b/App/Sources/Features/Settings/SettingsView.swift
@@ -10,10 +10,10 @@ struct SettingsView: View {
     @AppStorage(AppStorageKey.downloadEngine) private var selectedEngine = DownloadEngineKind.libcurl.rawValue
     #if os(macOS)
     @AppStorage(AppStorageKey.showsMenuBarIcon) private var showsMenuBarIcon = true
+    #endif
     @State private var defaultDownloadLocation: DefaultDownloadLocation
     @State private var locationBeforeCustomPicker: DefaultDownloadLocation?
     @State private var showsCustomDestinationPicker = false
-    #endif
     @State private var safariExtensionIsEnabled: Bool?
     @State private var presentedError: PresentedDownloadError?
     #if os(macOS)
@@ -23,9 +23,7 @@ struct SettingsView: View {
 
     init(service: DownloadService) {
         self.service = service
-        #if os(macOS)
         _defaultDownloadLocation = State(initialValue: service.defaultDownloadLocation)
-        #endif
     }
 
     var body: some View {
@@ -33,11 +31,14 @@ struct SettingsView: View {
             #if os(iOS)
             MobileSettingsFormContent(
                 defaultConnectionCount: $defaultConnectionCount,
+                defaultDownloadLocation: $defaultDownloadLocation,
                 selectedEngine: $selectedEngine,
                 engineDescriptors: service.engineDescriptors,
                 selectedDescriptor: selectedDescriptor,
                 safariExtensionIsEnabled: safariExtensionIsEnabled,
                 databaseURL: service.databaseURL,
+                defaultDestinationDirectory: service.defaultDestinationDirectory,
+                chooseCustomDefaultDestination: presentCustomDestinationPicker,
                 openSafariSettings: SafariExtensionSupport.showPreferences
             )
             #else
@@ -84,7 +85,6 @@ struct SettingsView: View {
         .onChange(of: selectedEngine) { _, _ in
             applyEngineSelection()
         }
-        #if os(macOS)
         .onChange(of: defaultDownloadLocation) { oldLocation, newLocation in
             applyDefaultDownloadLocation(
                 from: oldLocation,
@@ -98,7 +98,6 @@ struct SettingsView: View {
             onCompletion: applyCustomDestination,
             onCancellation: cancelCustomDestinationPicker
         )
-        #endif
         .alert(item: $presentedError) { error in
             Alert(
                 title: Text(error.title),
@@ -151,16 +150,25 @@ struct SettingsView: View {
     private func showBrowserExtensions() {
         openWindow(id: AppWindowID.browsers)
     }
+    #endif
 
     private func applyDefaultDownloadLocation(
         from oldLocation: DefaultDownloadLocation,
         to newLocation: DefaultDownloadLocation
     ) {
         guard newLocation != service.defaultDownloadLocation else { return }
-        if newLocation == .custom, !service.hasStoredCustomDefaultDestination {
+        if newLocation == .custom {
+            #if os(iOS)
             locationBeforeCustomPicker = oldLocation
             showsCustomDestinationPicker = true
             return
+            #else
+            if !service.hasStoredCustomDefaultDestination {
+                locationBeforeCustomPicker = oldLocation
+                showsCustomDestinationPicker = true
+                return
+            }
+            #endif
         }
 
         do {
@@ -208,7 +216,6 @@ struct SettingsView: View {
             ?? service.defaultDownloadLocation
         locationBeforeCustomPicker = nil
     }
-    #endif
 }
 
 #Preview {

--- a/App/Sources/Infrastructure/Persistence/DestinationBookmarkStore.swift
+++ b/App/Sources/Infrastructure/Persistence/DestinationBookmarkStore.swift
@@ -5,10 +5,23 @@ final class DestinationBookmarkStore {
     private struct Record: Codable {
         let path: String
         let bookmark: Data
+        let owners: [String]?
+    }
+
+    private struct Entry {
+        var bookmark: Data
+        var owners: Set<String>
+        var isLegacy: Bool
+
+        func mergingOwners(from existing: Self?) -> Self {
+            var merged = self
+            merged.owners.formUnion(existing?.owners ?? [])
+            return merged
+        }
     }
 
     private let storeURL: URL
-    private var bookmarksByPath: [String: Data]
+    private var entriesByPath: [String: Entry]
     private var activeURLsByPath: [String: URL] = [:]
 
     init(storeURL: URL) throws {
@@ -16,43 +29,122 @@ final class DestinationBookmarkStore {
         if FileManager.default.fileExists(atPath: storeURL.path) {
             let data = try Data(contentsOf: storeURL)
             let records = try PropertyListDecoder().decode([Record].self, from: data)
-            bookmarksByPath = Dictionary(
-                uniqueKeysWithValues: records.map { ($0.path, $0.bookmark) }
+            entriesByPath = Dictionary(
+                uniqueKeysWithValues: records.map { record in
+                    (
+                        record.path,
+                        Entry(
+                            bookmark: record.bookmark,
+                            owners: Set(record.owners ?? []),
+                            isLegacy: record.owners == nil
+                        )
+                    )
+                }
             )
         } else {
-            bookmarksByPath = [:]
+            entriesByPath = [:]
         }
-        try restoreAccess()
+        restoreAccess()
     }
 
     @discardableResult
-    func authorize(_ directory: URL) throws -> URL {
-        let standardizedURL = directory.standardizedFileURL
-        let path = standardizedURL.path(percentEncoded: false)
-        if let activeURL = activeURLsByPath[path] {
-            return activeURL
+    func authorize(_ directory: URL, owner: String) throws -> URL {
+        let requestedURL = directory.standardizedFileURL
+        let requestedPath = requestedURL.path(percentEncoded: false)
+        let path = if entriesByPath[requestedPath] != nil {
+            requestedPath
+        } else if let activePath = activeURLsByPath.first(where: { _, activeURL in
+            activeURL.standardizedFileURL == requestedURL
+        })?.key {
+            activePath
+        } else {
+            requestedPath
+        }
+        let previousEntries = entriesByPath
+        let wasAlreadyActive = activeURLsByPath[path] != nil
+        let authorizedURL: URL
+        let bookmark: Data
+        let didStartAccess: Bool
+
+        if let activeURL = activeURLsByPath[path],
+           let entry = entriesByPath[path] {
+            authorizedURL = activeURL
+            bookmark = entry.bookmark
+            didStartAccess = false
+        } else if let entry = entriesByPath[path] {
+            var isStale = false
+            authorizedURL = try URL(
+                resolvingBookmarkData: entry.bookmark,
+                options: Self.bookmarkResolutionOptions,
+                relativeTo: nil,
+                bookmarkDataIsStale: &isStale
+            ).standardizedFileURL
+            didStartAccess = authorizedURL.startAccessingSecurityScopedResource()
+            if isStale {
+                do {
+                    bookmark = try authorizedURL.bookmarkData(
+                        options: Self.bookmarkCreationOptions,
+                        includingResourceValuesForKeys: nil,
+                        relativeTo: nil
+                    )
+                } catch {
+                    if didStartAccess {
+                        authorizedURL.stopAccessingSecurityScopedResource()
+                    }
+                    throw error
+                }
+            } else {
+                bookmark = entry.bookmark
+            }
+        } else {
+            authorizedURL = requestedURL
+            didStartAccess = authorizedURL.startAccessingSecurityScopedResource()
+            do {
+                bookmark = try authorizedURL.bookmarkData(
+                    options: Self.bookmarkCreationOptions,
+                    includingResourceValuesForKeys: nil,
+                    relativeTo: nil
+                )
+            } catch {
+                if didStartAccess {
+                    authorizedURL.stopAccessingSecurityScopedResource()
+                }
+                throw error
+            }
         }
 
-        let didStartAccess = standardizedURL.startAccessingSecurityScopedResource()
-        let previousBookmark = bookmarksByPath[path]
+        removeOwner(owner)
+        entriesByPath[path] = Entry(
+            bookmark: bookmark,
+            owners: [owner],
+            isLegacy: false
+        ).mergingOwners(from: entriesByPath[path])
+        if didStartAccess {
+            activeURLsByPath[path] = authorizedURL
+        }
+
         do {
-            let bookmark = try standardizedURL.bookmarkData(
-                options: Self.bookmarkCreationOptions,
-                includingResourceValuesForKeys: nil,
-                relativeTo: nil
-            )
-            bookmarksByPath[path] = bookmark
-            if didStartAccess {
-                activeURLsByPath[path] = standardizedURL
-            }
             try persist()
-            return standardizedURL
+            stopUnownedAccess()
+            return authorizedURL
         } catch {
-            bookmarksByPath[path] = previousBookmark
-            activeURLsByPath[path] = nil
-            if didStartAccess {
-                standardizedURL.stopAccessingSecurityScopedResource()
+            entriesByPath = previousEntries
+            if didStartAccess, !wasAlreadyActive {
+                authorizedURL.stopAccessingSecurityScopedResource()
+                activeURLsByPath[path] = nil
             }
+            throw error
+        }
+    }
+
+    func release(owner: String) throws {
+        let previousEntries = entriesByPath
+        removeOwner(owner)
+        do {
+            try persist()
+            stopUnownedAccess()
+        } catch {
+            entriesByPath = previousEntries
             throw error
         }
     }
@@ -64,37 +156,65 @@ final class DestinationBookmarkStore {
         activeURLsByPath.removeAll()
     }
 
-    private func restoreAccess() throws {
-        var refreshedBookmarks = bookmarksByPath
-        for (storedPath, bookmark) in bookmarksByPath {
-            var isStale = false
-            let url = try URL(
-                resolvingBookmarkData: bookmark,
-                options: Self.bookmarkResolutionOptions,
-                relativeTo: nil,
-                bookmarkDataIsStale: &isStale
-            )
-            let standardizedURL = url.standardizedFileURL
-            if standardizedURL.startAccessingSecurityScopedResource() {
-                activeURLsByPath[storedPath] = standardizedURL
-            }
-            if isStale {
-                refreshedBookmarks[storedPath] = try standardizedURL.bookmarkData(
-                    options: Self.bookmarkCreationOptions,
-                    includingResourceValuesForKeys: nil,
-                    relativeTo: nil
-                )
+    private func removeOwner(_ owner: String) {
+        for path in entriesByPath.keys {
+            entriesByPath[path]?.owners.remove(owner)
+        }
+    }
+
+    private func stopUnownedAccess() {
+        let inactivePaths = activeURLsByPath.keys.filter { path in
+            guard let entry = entriesByPath[path] else { return true }
+            return entry.owners.isEmpty && !entry.isLegacy
+        }
+        for path in inactivePaths {
+            activeURLsByPath[path]?.stopAccessingSecurityScopedResource()
+            activeURLsByPath[path] = nil
+        }
+    }
+
+    private func restoreAccess() {
+        var didRefreshBookmark = false
+        for (storedPath, entry) in entriesByPath
+            where entry.isLegacy || !entry.owners.isEmpty {
+            do {
+                var isStale = false
+                let url = try URL(
+                    resolvingBookmarkData: entry.bookmark,
+                    options: Self.bookmarkResolutionOptions,
+                    relativeTo: nil,
+                    bookmarkDataIsStale: &isStale
+                ).standardizedFileURL
+                if url.startAccessingSecurityScopedResource() {
+                    activeURLsByPath[storedPath] = url
+                }
+                if isStale {
+                    entriesByPath[storedPath]?.bookmark = try url.bookmarkData(
+                        options: Self.bookmarkCreationOptions,
+                        includingResourceValuesForKeys: nil,
+                        relativeTo: nil
+                    )
+                    didRefreshBookmark = true
+                }
+            } catch {
+                // A provider can be temporarily offline. Keep its bookmark so the
+                // user can reconnect or replace it without disabling the store.
             }
         }
-        if refreshedBookmarks != bookmarksByPath {
-            bookmarksByPath = refreshedBookmarks
-            try persist()
+        if didRefreshBookmark {
+            try? persist()
         }
     }
 
     private func persist() throws {
-        let records = bookmarksByPath
-            .map { Record(path: $0.key, bookmark: $0.value) }
+        let records = entriesByPath
+            .map { path, entry in
+                Record(
+                    path: path,
+                    bookmark: entry.bookmark,
+                    owners: entry.isLegacy ? nil : entry.owners.sorted()
+                )
+            }
             .sorted { $0.path < $1.path }
         let data = try PropertyListEncoder().encode(records)
         try data.write(to: storeURL, options: .atomic)

--- a/App/Sources/Infrastructure/Persistence/DestinationBookmarkStore.swift
+++ b/App/Sources/Infrastructure/Persistence/DestinationBookmarkStore.swift
@@ -6,16 +6,21 @@ final class DestinationBookmarkStore {
         let path: String
         let bookmark: Data
         let owners: [String]?
+        let retainsBookmarkWhenUnowned: Bool?
     }
 
     private struct Entry {
         var bookmark: Data
         var owners: Set<String>
         var isLegacy: Bool
+        var retainsBookmarkWhenUnowned: Bool
 
-        func mergingOwners(from existing: Self?) -> Self {
+        func merging(from existing: Self?) -> Self {
             var merged = self
             merged.owners.formUnion(existing?.owners ?? [])
+            merged.retainsBookmarkWhenUnowned =
+                retainsBookmarkWhenUnowned ||
+                (existing?.retainsBookmarkWhenUnowned ?? false)
             return merged
         }
     }
@@ -36,7 +41,9 @@ final class DestinationBookmarkStore {
                         Entry(
                             bookmark: record.bookmark,
                             owners: Set(record.owners ?? []),
-                            isLegacy: record.owners == nil
+                            isLegacy: record.owners == nil,
+                            retainsBookmarkWhenUnowned:
+                                record.retainsBookmarkWhenUnowned ?? false
                         )
                     )
                 }
@@ -44,11 +51,20 @@ final class DestinationBookmarkStore {
         } else {
             entriesByPath = [:]
         }
+        let storedEntryCount = entriesByPath.count
+        pruneUnownedEntries()
+        if entriesByPath.count != storedEntryCount {
+            try persist()
+        }
         restoreAccess()
     }
 
     @discardableResult
-    func authorize(_ directory: URL, owner: String) throws -> URL {
+    func authorize(
+        _ directory: URL,
+        owner: String,
+        retainBookmarkWhenUnowned: Bool = false
+    ) throws -> URL {
         let requestedURL = directory.standardizedFileURL
         let requestedPath = requestedURL.path(percentEncoded: false)
         let path = if entriesByPath[requestedPath] != nil {
@@ -113,12 +129,14 @@ final class DestinationBookmarkStore {
             }
         }
 
-        removeOwner(owner)
+        relocateOwner(owner)
+        pruneUnownedEntries()
         entriesByPath[path] = Entry(
             bookmark: bookmark,
             owners: [owner],
-            isLegacy: false
-        ).mergingOwners(from: entriesByPath[path])
+            isLegacy: false,
+            retainsBookmarkWhenUnowned: retainBookmarkWhenUnowned
+        ).merging(from: entriesByPath[path])
         if didStartAccess {
             activeURLsByPath[path] = authorizedURL
         }
@@ -137,9 +155,16 @@ final class DestinationBookmarkStore {
         }
     }
 
-    func release(owner: String) throws {
+    func release(
+        owner: String,
+        retainBookmarkWhenUnowned: Bool = false
+    ) throws {
         let previousEntries = entriesByPath
-        removeOwner(owner)
+        removeOwner(
+            owner,
+            retainBookmarkWhenUnowned: retainBookmarkWhenUnowned
+        )
+        pruneUnownedEntries()
         do {
             try persist()
             stopUnownedAccess()
@@ -156,9 +181,32 @@ final class DestinationBookmarkStore {
         activeURLsByPath.removeAll()
     }
 
-    private func removeOwner(_ owner: String) {
-        for path in entriesByPath.keys {
+    private func relocateOwner(_ owner: String) {
+        for path in entriesByPath.keys
+            where entriesByPath[path]?.owners.contains(owner) == true {
             entriesByPath[path]?.owners.remove(owner)
+            entriesByPath[path]?.retainsBookmarkWhenUnowned = false
+        }
+    }
+
+    private func removeOwner(
+        _ owner: String,
+        retainBookmarkWhenUnowned: Bool
+    ) {
+        for path in entriesByPath.keys
+            where entriesByPath[path]?.owners.contains(owner) == true {
+            entriesByPath[path]?.owners.remove(owner)
+            if retainBookmarkWhenUnowned {
+                entriesByPath[path]?.retainsBookmarkWhenUnowned = true
+            }
+        }
+    }
+
+    private func pruneUnownedEntries() {
+        entriesByPath = entriesByPath.filter { _, entry in
+            entry.isLegacy ||
+                !entry.owners.isEmpty ||
+                entry.retainsBookmarkWhenUnowned
         }
     }
 
@@ -212,7 +260,9 @@ final class DestinationBookmarkStore {
                 Record(
                     path: path,
                     bookmark: entry.bookmark,
-                    owners: entry.isLegacy ? nil : entry.owners.sorted()
+                    owners: entry.isLegacy ? nil : entry.owners.sorted(),
+                    retainsBookmarkWhenUnowned:
+                        entry.retainsBookmarkWhenUnowned ? true : nil
                 )
             }
             .sorted { $0.path < $1.path }

--- a/App/Tests/SDMAppTests.swift
+++ b/App/Tests/SDMAppTests.swift
@@ -104,6 +104,126 @@ final class SDMAppTests: XCTestCase {
         restoredStore.stopAllAccess()
     }
 
+    #if os(macOS)
+    @MainActor
+    func testDefaultDownloadDestinationSelectionPersistsAndCreatesFolders() async throws {
+        let root = FileManager.default.temporaryDirectory.appending(
+            path: UUID().uuidString,
+            directoryHint: .isDirectory
+        )
+        let downloads = root.appending(path: "Downloads", directoryHint: .isDirectory)
+        let appSandbox = root.appending(path: "AppData", directoryHint: .isDirectory)
+        let custom = root.appending(path: "Custom", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: downloads, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: custom, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let suiteName = "SDMAppTests.\(UUID().uuidString)"
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+        let bookmarks = try DestinationBookmarkStore(
+            storeURL: root.appending(path: "destination-bookmarks.plist")
+        )
+        let directories = DefaultDownloadDestinationDirectories(
+            appSandbox: appSandbox,
+            downloads: downloads
+        )
+        let service = try DownloadService(
+            configuration: DownloadManagerConfiguration(
+                databaseURL: root.appending(path: "downloads.sqlite3"),
+                temporaryDirectory: root.appending(
+                    path: "PartialDownloads",
+                    directoryHint: .isDirectory
+                )
+            ),
+            destinationDirectory: downloads,
+            destinationBookmarks: bookmarks,
+            defaultDownloadLocation: .downloads,
+            defaultDestinationDirectories: directories,
+            userDefaults: userDefaults
+        )
+
+        try service.selectDefaultDestination(.appSandbox)
+        XCTAssertEqual(service.defaultDownloadLocation, .appSandbox)
+        XCTAssertEqual(service.defaultDestinationDirectory, appSandbox.standardizedFileURL)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: appSandbox.path))
+
+        try service.selectDefaultDestination(.downloadsSDM)
+        XCTAssertEqual(service.defaultDestinationDirectory, directories.downloadsSDM)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: directories.downloadsSDM.path))
+
+        try service.selectDefaultDestination(.custom, customDirectory: custom)
+        XCTAssertEqual(service.defaultDownloadLocation, .custom)
+        XCTAssertEqual(service.defaultDestinationDirectory, custom.standardizedFileURL)
+        XCTAssertEqual(
+            userDefaults.string(forKey: AppStorageKey.defaultDownloadLocation),
+            DefaultDownloadLocation.custom.rawValue
+        )
+        XCTAssertEqual(
+            userDefaults.string(forKey: AppStorageKey.customDefaultDownloadDirectory),
+            custom.path(percentEncoded: false)
+        )
+
+        await service.shutdown()
+    }
+
+    func testDefaultDownloadDestinationDirectoryMapping() {
+        let directories = DefaultDownloadDestinationDirectories(
+            appSandbox: URL(filePath: "/AppData/Downloads", directoryHint: .isDirectory),
+            downloads: URL(filePath: "/Users/example/Downloads", directoryHint: .isDirectory)
+        )
+
+        XCTAssertEqual(directories.directory(for: .appSandbox), directories.appSandbox)
+        XCTAssertEqual(directories.directory(for: .downloads), directories.downloads)
+        XCTAssertEqual(directories.directory(for: .downloadsSDM), directories.downloadsSDM)
+        XCTAssertNil(directories.directory(for: .custom))
+    }
+
+    func testDefaultDownloadDestinationResolvesSandboxDownloadsSymlink() throws {
+        let root = FileManager.default.temporaryDirectory.appending(
+            path: UUID().uuidString,
+            directoryHint: .isDirectory
+        )
+        let containerData = root.appending(
+            path: "ContainerData",
+            directoryHint: .isDirectory
+        )
+        let actualDownloads = root.appending(
+            path: "UserDownloads",
+            directoryHint: .isDirectory
+        )
+        try FileManager.default.createDirectory(
+            at: containerData,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: actualDownloads,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let sandboxDownloads = containerData.appending(
+            path: "Downloads",
+            directoryHint: .isDirectory
+        )
+        try FileManager.default.createSymbolicLink(
+            at: sandboxDownloads,
+            withDestinationURL: actualDownloads
+        )
+
+        let directories = DefaultDownloadDestinationDirectories(
+            appSandbox: root.appending(path: "AppData", directoryHint: .isDirectory),
+            downloads: sandboxDownloads
+        )
+
+        XCTAssertEqual(directories.downloads, actualDownloads.standardizedFileURL)
+        XCTAssertEqual(
+            directories.downloadsSDM,
+            actualDownloads.appending(path: "SDM", directoryHint: .isDirectory)
+        )
+    }
+    #endif
+
     func testAppStoragePathsStayUnderInjectedApplicationSupportDirectory() throws {
         let applicationSupport = FileManager.default.temporaryDirectory.appending(
             path: UUID().uuidString,

--- a/App/Tests/SDMAppTests.swift
+++ b/App/Tests/SDMAppTests.swift
@@ -164,6 +164,19 @@ final class SDMAppTests: XCTestCase {
         restoredStore.stopAllAccess()
     }
 
+    func testDefaultDownloadLocationsExcludeRemovedSDMSubfolder() {
+        XCTAssertNil(DefaultDownloadLocation(rawValue: "downloadsSDM"))
+        XCTAssertEqual(DefaultDownloadLocation.downloads.title, "Downloads Folder")
+        #if os(macOS)
+        XCTAssertEqual(
+            DefaultDownloadLocation.availableLocations,
+            [.appSandbox, .downloads, .custom]
+        )
+        #else
+        XCTAssertEqual(DefaultDownloadLocation.availableLocations, [.appSandbox, .custom])
+        #endif
+    }
+
     #if os(macOS)
     @MainActor
     func testDefaultDownloadDestinationSelectionPersistsAndCreatesFolders() async throws {
@@ -208,11 +221,6 @@ final class SDMAppTests: XCTestCase {
         XCTAssertEqual(service.defaultDestinationDirectory, appSandbox.standardizedFileURL)
         XCTAssertTrue(FileManager.default.fileExists(atPath: appSandbox.path))
 
-        try service.selectDefaultDestination(.downloadsSDM)
-        let downloadsSDM = try XCTUnwrap(directories.downloadsSDM)
-        XCTAssertEqual(service.defaultDestinationDirectory, downloadsSDM)
-        XCTAssertTrue(FileManager.default.fileExists(atPath: downloadsSDM.path))
-
         try service.selectDefaultDestination(.custom, customDirectory: custom)
         XCTAssertEqual(service.defaultDownloadLocation, .custom)
         XCTAssertEqual(service.defaultDestinationDirectory, custom.standardizedFileURL)
@@ -236,7 +244,6 @@ final class SDMAppTests: XCTestCase {
 
         XCTAssertEqual(directories.directory(for: .appSandbox), directories.appSandbox)
         XCTAssertEqual(directories.directory(for: .downloads), directories.downloads)
-        XCTAssertEqual(directories.directory(for: .downloadsSDM), directories.downloadsSDM)
         XCTAssertNil(directories.directory(for: .custom))
     }
 
@@ -279,10 +286,6 @@ final class SDMAppTests: XCTestCase {
 
         XCTAssertEqual(directories.appSandbox, sandboxDownloads.standardizedFileURL)
         XCTAssertEqual(directories.downloads, actualDownloads.standardizedFileURL)
-        XCTAssertEqual(
-            directories.downloadsSDM,
-            actualDownloads.appending(path: "SDM", directoryHint: .isDirectory)
-        )
     }
     #endif
 
@@ -328,7 +331,6 @@ final class SDMAppTests: XCTestCase {
         XCTAssertEqual(service.defaultDownloadLocation, .appSandbox)
         XCTAssertEqual(service.defaultDestinationDirectory, documents.standardizedFileURL)
         XCTAssertNil(directories.directory(for: .downloads))
-        XCTAssertNil(directories.directory(for: .downloadsSDM))
 
         await service.shutdown()
     }

--- a/App/Tests/SDMAppTests.swift
+++ b/App/Tests/SDMAppTests.swift
@@ -96,8 +96,12 @@ final class SDMAppTests: XCTestCase {
         let storeURL = root.appending(path: "destination-bookmarks.plist")
 
         let firstStore = try DestinationBookmarkStore(storeURL: storeURL)
-        XCTAssertEqual(try firstStore.authorize(destination), destination.standardizedFileURL)
+        XCTAssertEqual(
+            try firstStore.authorize(destination, owner: "test"),
+            destination.standardizedFileURL
+        )
         XCTAssertTrue(FileManager.default.fileExists(atPath: storeURL.path))
+        try firstStore.release(owner: "test")
         firstStore.stopAllAccess()
 
         let restoredStore = try DestinationBookmarkStore(storeURL: storeURL)
@@ -149,8 +153,9 @@ final class SDMAppTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: appSandbox.path))
 
         try service.selectDefaultDestination(.downloadsSDM)
-        XCTAssertEqual(service.defaultDestinationDirectory, directories.downloadsSDM)
-        XCTAssertTrue(FileManager.default.fileExists(atPath: directories.downloadsSDM.path))
+        let downloadsSDM = try XCTUnwrap(directories.downloadsSDM)
+        XCTAssertEqual(service.defaultDestinationDirectory, downloadsSDM)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: downloadsSDM.path))
 
         try service.selectDefaultDestination(.custom, customDirectory: custom)
         XCTAssertEqual(service.defaultDownloadLocation, .custom)
@@ -223,6 +228,53 @@ final class SDMAppTests: XCTestCase {
         )
     }
     #endif
+
+    @MainActor
+    func testDocumentsAndExternalDefaultDestinationsRemainSelectable() async throws {
+        let root = FileManager.default.temporaryDirectory.appending(
+            path: UUID().uuidString,
+            directoryHint: .isDirectory
+        )
+        let documents = root.appending(path: "Documents", directoryHint: .isDirectory)
+        let external = root.appending(path: "External", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: documents, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: external, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let suiteName = "SDMAppTests.\(UUID().uuidString)"
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+        let bookmarks = try DestinationBookmarkStore(
+            storeURL: root.appending(path: "destination-bookmarks.plist")
+        )
+        let directories = DefaultDownloadDestinationDirectories(appSandbox: documents)
+        let service = try DownloadService(
+            configuration: DownloadManagerConfiguration(
+                databaseURL: root.appending(path: "downloads.sqlite3"),
+                temporaryDirectory: root.appending(
+                    path: "PartialDownloads",
+                    directoryHint: .isDirectory
+                )
+            ),
+            destinationDirectory: documents,
+            destinationBookmarks: bookmarks,
+            defaultDownloadLocation: .appSandbox,
+            defaultDestinationDirectories: directories,
+            userDefaults: userDefaults
+        )
+
+        try service.selectDefaultDestination(.custom, customDirectory: external)
+        XCTAssertEqual(service.defaultDownloadLocation, .custom)
+        XCTAssertEqual(service.defaultDestinationDirectory, external.standardizedFileURL)
+
+        try service.selectDefaultDestination(.appSandbox)
+        XCTAssertEqual(service.defaultDownloadLocation, .appSandbox)
+        XCTAssertEqual(service.defaultDestinationDirectory, documents.standardizedFileURL)
+        XCTAssertNil(directories.directory(for: .downloads))
+        XCTAssertNil(directories.directory(for: .downloadsSDM))
+
+        await service.shutdown()
+    }
 
     func testAppStoragePathsStayUnderInjectedApplicationSupportDirectory() throws {
         let applicationSupport = FileManager.default.temporaryDirectory.appending(

--- a/App/Tests/SDMAppTests.swift
+++ b/App/Tests/SDMAppTests.swift
@@ -104,7 +104,63 @@ final class SDMAppTests: XCTestCase {
         try firstStore.release(owner: "test")
         firstStore.stopAllAccess()
 
+        let releasedRecords = try XCTUnwrap(
+            PropertyListSerialization.propertyList(
+                from: Data(contentsOf: storeURL),
+                format: nil
+            ) as? [[String: Any]]
+        )
+        XCTAssertTrue(releasedRecords.isEmpty)
+
         let restoredStore = try DestinationBookmarkStore(storeURL: storeURL)
+        restoredStore.stopAllAccess()
+    }
+
+    @MainActor
+    func testDestinationBookmarkStoreRetainsSavedDefaultWithoutAnOwner() throws {
+        let root = FileManager.default.temporaryDirectory.appending(
+            path: UUID().uuidString,
+            directoryHint: .isDirectory
+        )
+        let destination = root.appending(path: "Destination", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let storeURL = root.appending(path: "destination-bookmarks.plist")
+
+        let firstStore = try DestinationBookmarkStore(storeURL: storeURL)
+        _ = try firstStore.authorize(
+            destination,
+            owner: "default",
+            retainBookmarkWhenUnowned: true
+        )
+        try firstStore.release(
+            owner: "default",
+            retainBookmarkWhenUnowned: true
+        )
+        firstStore.stopAllAccess()
+
+        let releasedRecords = try XCTUnwrap(
+            PropertyListSerialization.propertyList(
+                from: Data(contentsOf: storeURL),
+                format: nil
+            ) as? [[String: Any]]
+        )
+        XCTAssertEqual(releasedRecords.count, 1)
+        XCTAssertEqual(releasedRecords.first?["owners"] as? [String], [])
+        XCTAssertEqual(
+            releasedRecords.first?["retainsBookmarkWhenUnowned"] as? Bool,
+            true
+        )
+
+        let restoredStore = try DestinationBookmarkStore(storeURL: storeURL)
+        XCTAssertEqual(
+            try restoredStore.authorize(
+                destination,
+                owner: "default",
+                retainBookmarkWhenUnowned: true
+            ),
+            destination.standardizedFileURL
+        )
         restoredStore.stopAllAccess()
     }
 
@@ -217,10 +273,11 @@ final class SDMAppTests: XCTestCase {
         )
 
         let directories = DefaultDownloadDestinationDirectories(
-            appSandbox: root.appending(path: "AppData", directoryHint: .isDirectory),
+            appSandbox: sandboxDownloads,
             downloads: sandboxDownloads
         )
 
+        XCTAssertEqual(directories.appSandbox, sandboxDownloads.standardizedFileURL)
         XCTAssertEqual(directories.downloads, actualDownloads.standardizedFileURL)
         XCTAssertEqual(
             directories.downloadsSDM,
@@ -383,6 +440,7 @@ final class SDMAppTests: XCTestCase {
         XCTAssertTrue(DownloadState.paused.allows(.resume))
         XCTAssertTrue(DownloadState.paused.allows(.remove))
         XCTAssertTrue(DownloadState.failed.allows(.retry))
+        XCTAssertFalse(DownloadState.finalizing.allows(.cancel))
         XCTAssertFalse(DownloadState.completed.allows(.cancel))
     }
 

--- a/Docs/SDMCore.md
+++ b/Docs/SDMCore.md
@@ -75,7 +75,11 @@ Both backends finalize through coordinated file access. Core first attempts an
 atomic move, then falls back to copying into a sibling staging file, syncing it,
 and committing it at the destination. This supports destinations in iCloud
 Drive and third-party File Provider domains without exposing a partially copied
-file or removing an existing file before the replacement is ready.
+file or removing an existing file before the replacement is ready. Non-replacing
+commits use an exclusive rename so a concurrently created destination is never
+overwritten. The libcurl engine performs potentially slow cross-volume copies on
+a dedicated finalization worker, while URLSession sequences background-event
+completion after coordinated finalization and persistence.
 
 Recovery changes in-flight tasks to `paused`. Resume uses persisted Range
 offsets and `If-Range` validators; an incompatible response fails before new

--- a/Docs/SDMCore.md
+++ b/Docs/SDMCore.md
@@ -71,6 +71,12 @@ must keep destination access active for the lifetime of the transfer. Core
 persists paths and transfer metadata, but never persists credentials, cookies,
 or request headers.
 
+Both backends finalize through coordinated file access. Core first attempts an
+atomic move, then falls back to copying into a sibling staging file, syncing it,
+and committing it at the destination. This supports destinations in iCloud
+Drive and third-party File Provider domains without exposing a partially copied
+file or removing an existing file before the replacement is ready.
+
 Recovery changes in-flight tasks to `paused`. Resume uses persisted Range
 offsets and `If-Range` validators; an incompatible response fails before new
 bytes can be written into the partial representation.

--- a/Packages/SDMCore/Package.swift
+++ b/Packages/SDMCore/Package.swift
@@ -34,6 +34,7 @@ let package = Package(
                 .linkedLibrary("sqlite3"),
                 .linkedLibrary("z"),
                 .linkedLibrary("ldap", .when(platforms: [.macOS])),
+                .linkedFramework("Foundation"),
                 .linkedFramework("CoreFoundation"),
                 .linkedFramework("Security"),
                 .linkedFramework("SystemConfiguration"),

--- a/Packages/SDMCore/Sources/SDMCore/Backends/URLSession/URLSessionDelegateTaskTracker.swift
+++ b/Packages/SDMCore/Sources/SDMCore/Backends/URLSession/URLSessionDelegateTaskTracker.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Tracks terminal delegate work that must finish before iOS suspends a
+/// background URLSession wake.
+final class URLSessionDelegateTaskTracker: @unchecked Sendable {
+    typealias Operation = @Sendable () async -> Void
+
+    private let lock = NSLock()
+    private var tasks: [UUID: Task<Void, Never>] = [:]
+
+    func start(_ operation: @escaping Operation) {
+        let token = UUID()
+        let task = Task {
+            await operation()
+        }
+        lock.withLock {
+            tasks[token] = task
+        }
+        Task { [weak self] in
+            await task.value
+            self?.remove(token)
+        }
+    }
+
+    func waitForTrackedTasks() async {
+        let pendingTasks = lock.withLock {
+            Array(tasks.values)
+        }
+        for task in pendingTasks {
+            await task.value
+        }
+    }
+
+    private func remove(_ token: UUID) {
+        lock.withLock {
+            tasks[token] = nil
+        }
+    }
+}

--- a/Packages/SDMCore/Sources/SDMCore/Backends/URLSession/URLSessionDownloadBackend.swift
+++ b/Packages/SDMCore/Sources/SDMCore/Backends/URLSession/URLSessionDownloadBackend.swift
@@ -332,7 +332,11 @@ actor URLSessionDownloadBackend: DownloadEngineBackend {
                 at: record.request.destinationDirectory,
                 withIntermediateDirectories: true
             )
-            try FileManager.default.moveItem(at: stagedURL, to: destinationURL)
+            try CoordinatedFileFinalizer.move(
+                from: stagedURL,
+                to: destinationURL,
+                replacesExisting: record.request.conflictPolicy == .replace
+            )
             let now = Date.now
             let fileSize = try? destinationURL.resourceValues(forKeys: [.fileSizeKey]).fileSize
             let contentLength = fileSize.map(UInt64.init)
@@ -592,7 +596,6 @@ actor URLSessionDownloadBackend: DownloadEngineBackend {
         guard FileManager.default.fileExists(atPath: original.path) else { return original }
         switch policy {
         case .replace:
-            try FileManager.default.removeItem(at: original)
             return original
         case .fail:
             throw DownloadError(

--- a/Packages/SDMCore/Sources/SDMCore/Backends/URLSession/URLSessionDownloadBackend.swift
+++ b/Packages/SDMCore/Sources/SDMCore/Backends/URLSession/URLSessionDownloadBackend.swift
@@ -295,7 +295,7 @@ actor URLSessionDownloadBackend: DownloadEngineBackend {
         suggestedFilename: String?,
         statusCode: Int?,
         expectedContentLength: Int64
-    ) {
+    ) async {
         guard var record = records[downloadID],
               record.snapshot.state != .cancelled else {
             try? FileManager.default.removeItem(at: stagedURL)
@@ -332,7 +332,27 @@ actor URLSessionDownloadBackend: DownloadEngineBackend {
                 at: record.request.destinationDirectory,
                 withIntermediateDirectories: true
             )
-            try CoordinatedFileFinalizer.move(
+            let finalizingAt = Date.now
+            let expectedLength = expectedContentLength > 0
+                ? UInt64(expectedContentLength)
+                : record.snapshot.contentLength
+            record.snapshot = record.snapshot.replacing(
+                finalURL: .some(finalURL),
+                destinationURL: .some(destinationURL),
+                filename: destinationURL.lastPathComponent,
+                state: .finalizing,
+                contentLength: .some(expectedLength),
+                downloadedBytes: expectedLength ?? record.snapshot.downloadedBytes,
+                bytesPerSecond: 0,
+                estimatedTimeRemaining: .some(nil),
+                error: .some(nil),
+                updatedAt: finalizingAt
+            )
+            records[downloadID] = record
+            try persist()
+            broadcast()
+
+            try await CoordinatedFileFinalizer.moveOffActor(
                 from: stagedURL,
                 to: destinationURL,
                 replacesExisting: record.request.conflictPolicy == .replace

--- a/Packages/SDMCore/Sources/SDMCore/Backends/URLSession/URLSessionDownloadDelegateBridge.swift
+++ b/Packages/SDMCore/Sources/SDMCore/Backends/URLSession/URLSessionDownloadDelegateBridge.swift
@@ -5,6 +5,7 @@ final class URLSessionDownloadDelegateBridge: NSObject, URLSessionDownloadDelega
     weak var backend: URLSessionDownloadBackend?
 
     private let stagingDirectory: URL
+    private let terminalTasks = URLSessionDelegateTaskTracker()
 
     init(stagingDirectory: URL) {
         self.stagingDirectory = stagingDirectory
@@ -44,7 +45,7 @@ final class URLSessionDownloadDelegateBridge: NSObject, URLSessionDownloadDelega
             }
             try FileManager.default.moveItem(at: location, to: stagedURL)
             let response = downloadTask.response as? HTTPURLResponse
-            Task { [weak backend] in
+            terminalTasks.start { [weak backend] in
                 await backend?.didFinish(
                     downloadID: id,
                     stagedURL: stagedURL,
@@ -55,7 +56,7 @@ final class URLSessionDownloadDelegateBridge: NSObject, URLSessionDownloadDelega
                 )
             }
         } catch {
-            Task { [weak backend] in
+            terminalTasks.start { [weak backend] in
                 await backend?.didFail(
                     downloadID: id,
                     code: .inputOutput,
@@ -74,7 +75,7 @@ final class URLSessionDownloadDelegateBridge: NSObject, URLSessionDownloadDelega
         guard let error, let id = downloadID(for: task) else { return }
         let nsError = error as NSError
         let resumeData = nsError.userInfo[NSURLSessionDownloadTaskResumeData] as? Data
-        Task { [weak backend] in
+        terminalTasks.start { [weak backend] in
             await backend?.didFail(
                 downloadID: id,
                 code: nsError.code == NSURLErrorCancelled ? .invalidState : .network,
@@ -86,7 +87,8 @@ final class URLSessionDownloadDelegateBridge: NSObject, URLSessionDownloadDelega
 
     func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
         guard let identifier = session.configuration.identifier else { return }
-        Task { [weak backend] in
+        Task { [weak backend, terminalTasks] in
+            await terminalTasks.waitForTrackedTasks()
             await backend?.didFinishBackgroundEvents(identifier: identifier)
         }
     }

--- a/Packages/SDMCore/Sources/SDMCore/Support/CoordinatedFileFinalizer.swift
+++ b/Packages/SDMCore/Sources/SDMCore/Support/CoordinatedFileFinalizer.swift
@@ -1,0 +1,49 @@
+import Foundation
+import SDMEngineBridge
+
+enum CoordinatedFileFinalizer {
+    static func move(
+        from source: URL,
+        to destination: URL,
+        replacesExisting: Bool
+    ) throws {
+        let sourcePath = source.path(percentEncoded: false)
+        let destinationPath = destination.path(percentEncoded: false)
+        var errorMessage = [CChar](repeating: 0, count: 1_024)
+        let result = withStringView(sourcePath) { sourceView in
+            withStringView(destinationPath) { destinationView in
+                errorMessage.withUnsafeMutableBufferPointer { buffer in
+                    sdm_finalize_file(
+                        sourceView,
+                        destinationView,
+                        replacesExisting ? 1 : 0,
+                        buffer.baseAddress,
+                        buffer.count
+                    )
+                }
+            }
+        }
+        guard result == SDM_RESULT_OK else {
+            let message = errorMessage.withUnsafeBufferPointer { buffer in
+                guard let baseAddress = buffer.baseAddress else { return "" }
+                return String(cString: baseAddress)
+            }
+            throw DownloadError(
+                code: .inputOutput,
+                message: message.isEmpty
+                    ? "The downloaded file could not be saved."
+                    : message
+            )
+        }
+    }
+
+    private static func withStringView<Result>(
+        _ value: String,
+        _ body: (sdm_string_view_t) throws -> Result
+    ) rethrows -> Result {
+        try value.utf8CString.withUnsafeBufferPointer { buffer in
+            let count = max(buffer.count - 1, 0)
+            return try body(sdm_string_view_t(data: buffer.baseAddress, length: count))
+        }
+    }
+}

--- a/Packages/SDMCore/Sources/SDMCore/Support/CoordinatedFileFinalizer.swift
+++ b/Packages/SDMCore/Sources/SDMCore/Support/CoordinatedFileFinalizer.swift
@@ -2,6 +2,33 @@ import Foundation
 import SDMEngineBridge
 
 enum CoordinatedFileFinalizer {
+    static func moveOffActor(
+        from source: URL,
+        to destination: URL,
+        replacesExisting: Bool
+    ) async throws {
+        let failure = await Task.detached(priority: .utility) {
+            do {
+                try move(
+                    from: source,
+                    to: destination,
+                    replacesExisting: replacesExisting
+                )
+                return nil as DownloadError?
+            } catch let error as DownloadError {
+                return error
+            } catch {
+                return DownloadError(
+                    code: .inputOutput,
+                    message: error.localizedDescription
+                )
+            }
+        }.value
+        if let failure {
+            throw failure
+        }
+    }
+
     static func move(
         from source: URL,
         to destination: URL,

--- a/Packages/SDMCore/Sources/SDMEngine/Engine.cpp
+++ b/Packages/SDMCore/Sources/SDMEngine/Engine.cpp
@@ -1,5 +1,6 @@
 #include "SDMEngine.h"
 #include "DownloadStore.h"
+#include "SDMFileFinalizer.h"
 
 #include <curl/curl.h>
 
@@ -1407,14 +1408,18 @@ private:
         }
         close_file(task);
 
-        std::error_code error;
-        if (task.request.conflict_policy == 1) {
-            std::filesystem::remove(task.destination_path, error);
-            error.clear();
-        }
-        std::filesystem::rename(task.temporary_path, task.destination_path, error);
-        if (error) {
-            fail_task(task, Result::io_error, "Unable to finalize downloaded file");
+        std::string finalization_error;
+        if (!finalize_file(
+                task.temporary_path,
+                task.destination_path,
+                task.request.conflict_policy == 1,
+                finalization_error
+            )) {
+            fail_task(
+                task,
+                Result::io_error,
+                "Unable to finalize downloaded file: " + finalization_error
+            );
             return;
         }
         task.snapshot.state = DownloadState::completed;

--- a/Packages/SDMCore/Sources/SDMEngine/Engine.cpp
+++ b/Packages/SDMCore/Sources/SDMEngine/Engine.cpp
@@ -225,6 +225,9 @@ public:
             multi = nullptr;
             throw PersistenceError(error.what());
         }
+        finalization_worker = std::jthread([this](std::stop_token stop_token) {
+            run_finalization_worker(stop_token);
+        });
         worker = std::jthread([this](std::stop_token stop_token) {
             run(stop_token);
         });
@@ -294,6 +297,19 @@ public:
         bool response_validated = false;
         bool protocol_failed = false;
         bool write_failed = false;
+    };
+
+    struct FinalizationJob final {
+        std::string id;
+        std::filesystem::path source;
+        std::filesystem::path destination;
+        bool replaces_existing = false;
+    };
+
+    struct FinalizationResult final {
+        std::string id;
+        bool completed = false;
+        std::string error_message;
     };
 
     Result enqueue(DownloadRequest request, std::uint64_t &command_id) {
@@ -410,6 +426,11 @@ public:
         wake();
         if (worker.joinable()) {
             worker.join();
+        }
+        finalization_worker.request_stop();
+        finalization_condition.notify_all();
+        if (finalization_worker.joinable()) {
+            finalization_worker.join();
         }
     }
 
@@ -529,7 +550,22 @@ private:
                 .result = Result::ok,
             });
         }
-        while (!stop_token.stop_requested()) {
+        bool stopped_transfers = false;
+        while (true) {
+            process_finalization_results();
+            if (stop_token.stop_requested()) {
+                if (!stopped_transfers) {
+                    stop_all_transfers();
+                    stopped_transfers = true;
+                }
+                if (!has_outstanding_finalizations()) {
+                    break;
+                }
+                std::unique_lock lock(mutex);
+                condition.wait_for(lock, std::chrono::milliseconds(25));
+                continue;
+            }
+
             process_commands();
             schedule_queued_tasks();
 
@@ -544,21 +580,18 @@ private:
             process_completed_transfers();
             publish_progress();
 
-            if (stop_token.stop_requested()) {
-                break;
-            }
             if (running_handles > 0) {
                 int descriptor_count = 0;
                 (void)curl_multi_poll(multi, nullptr, 0, 25, &descriptor_count);
             } else {
                 std::unique_lock lock(mutex);
-                condition.wait_for(lock, std::chrono::milliseconds(25), [this] {
-                    return !commands.empty() || stopping;
-                });
+                condition.wait_for(lock, std::chrono::milliseconds(25));
             }
         }
 
-        stop_all_transfers();
+        if (!stopped_transfers) {
+            stop_all_transfers();
+        }
         for (auto &[id, task] : tasks) {
             (void)id;
             update_snapshot_segments(*task);
@@ -1408,27 +1441,97 @@ private:
         }
         close_file(task);
 
-        std::string finalization_error;
-        if (!finalize_file(
-                task.temporary_path,
-                task.destination_path,
-                task.request.conflict_policy == 1,
-                finalization_error
-            )) {
-            fail_task(
-                task,
-                Result::io_error,
-                "Unable to finalize downloaded file: " + finalization_error
-            );
-            return;
+        {
+            std::lock_guard lock(finalization_mutex);
+            finalization_jobs.push_back(FinalizationJob{
+                .id = task.request.id,
+                .source = task.temporary_path,
+                .destination = task.destination_path,
+                .replaces_existing = task.request.conflict_policy == 1,
+            });
+            ++outstanding_finalizations;
         }
-        task.snapshot.state = DownloadState::completed;
-        task.snapshot.completed_milliseconds = current_milliseconds();
-        task.retry_attempt = 0;
-        task.retry_at.reset();
-        task.snapshot.bytes_per_second = 0;
-        task.snapshot.estimated_seconds_remaining = 0;
-        publish_snapshot(task);
+        finalization_condition.notify_one();
+    }
+
+    void run_finalization_worker(std::stop_token stop_token) noexcept {
+        while (true) {
+            FinalizationJob job;
+            {
+                std::unique_lock lock(finalization_mutex);
+                finalization_condition.wait(lock, stop_token, [this] {
+                    return !finalization_jobs.empty();
+                });
+                if (finalization_jobs.empty()) {
+                    if (stop_token.stop_requested()) {
+                        return;
+                    }
+                    continue;
+                }
+                job = std::move(finalization_jobs.front());
+                finalization_jobs.pop_front();
+            }
+
+            std::string error_message;
+            const auto completed = finalize_file(
+                job.source,
+                job.destination,
+                job.replaces_existing,
+                error_message
+            );
+            {
+                std::lock_guard lock(finalization_mutex);
+                finalization_results.push_back(FinalizationResult{
+                    .id = std::move(job.id),
+                    .completed = completed,
+                    .error_message = std::move(error_message),
+                });
+            }
+            wake();
+        }
+    }
+
+    void process_finalization_results() {
+        std::deque<FinalizationResult> results;
+        {
+            std::lock_guard lock(finalization_mutex);
+            results.swap(finalization_results);
+        }
+
+        for (auto &result : results) {
+            const auto iterator = tasks.find(result.id);
+            if (iterator != tasks.end()) {
+                auto &task = *iterator->second;
+                if (result.completed) {
+                    task.snapshot.state = DownloadState::completed;
+                    task.snapshot.completed_milliseconds = current_milliseconds();
+                    task.retry_attempt = 0;
+                    task.retry_at.reset();
+                    task.snapshot.bytes_per_second = 0;
+                    task.snapshot.estimated_seconds_remaining = 0;
+                    publish_snapshot(task);
+                } else {
+                    fail_task(
+                        task,
+                        Result::io_error,
+                        "Unable to finalize downloaded file: " + result.error_message
+                    );
+                }
+            }
+
+            {
+                std::lock_guard lock(finalization_mutex);
+                if (outstanding_finalizations > 0) {
+                    --outstanding_finalizations;
+                }
+            }
+            finalization_condition.notify_all();
+        }
+    }
+
+    bool has_outstanding_finalizations() {
+        std::lock_guard lock(finalization_mutex);
+        return outstanding_finalizations > 0;
     }
 
     void publish_progress() {
@@ -1745,9 +1848,15 @@ private:
     std::unordered_map<std::string, std::unique_ptr<Task>> tasks;
     std::vector<std::string> task_order;
     std::unordered_map<CURL *, std::unique_ptr<Transfer>> transfers;
+    std::mutex finalization_mutex;
+    std::condition_variable_any finalization_condition;
+    std::deque<FinalizationJob> finalization_jobs;
+    std::deque<FinalizationResult> finalization_results;
+    std::size_t outstanding_finalizations = 0;
     std::uint64_t next_command_id = 1;
     std::uint64_t next_event_sequence = 1;
     bool stopping = false;
+    std::jthread finalization_worker;
     std::jthread worker;
 };
 

--- a/Packages/SDMCore/Sources/SDMEngine/FileFinalizer.mm
+++ b/Packages/SDMCore/Sources/SDMEngine/FileFinalizer.mm
@@ -2,8 +2,11 @@
 
 #include "SDMFileFinalizer.h"
 
+#include <cerrno>
 #include <cstdio>
+#include <fcntl.h>
 #include <string>
+#include <sys/stdio.h>
 
 namespace {
 
@@ -21,6 +24,28 @@ NSError *file_exists_error(NSURL *destination) {
     return [NSError errorWithDomain:NSCocoaErrorDomain
                                code:NSFileWriteFileExistsError
                            userInfo:@{NSFilePathErrorKey: destination.path}];
+}
+
+bool exclusive_rename(NSURL *source, NSURL *destination, NSError **error) {
+    if (::renameatx_np(
+            AT_FDCWD,
+            source.fileSystemRepresentation,
+            AT_FDCWD,
+            destination.fileSystemRepresentation,
+            RENAME_EXCL
+        ) == 0) {
+        return true;
+    }
+
+    const auto error_code = errno;
+    if (error != nullptr) {
+        *error = error_code == EEXIST
+            ? file_exists_error(destination)
+            : [NSError errorWithDomain:NSPOSIXErrorDomain
+                                   code:error_code
+                               userInfo:@{NSFilePathErrorKey: destination.path}];
+    }
+    return false;
 }
 
 bool synchronize_file(NSURL *url, NSError **error) {
@@ -93,12 +118,27 @@ bool finalize_file(
                         return;
                     }
 
-                    if (::rename(
-                            coordinated_source.fileSystemRepresentation,
-                            coordinated_destination.fileSystemRepresentation
-                        ) == 0) {
-                        completed = true;
-                        return;
+                    if (replaces_existing) {
+                        if (::rename(
+                                coordinated_source.fileSystemRepresentation,
+                                coordinated_destination.fileSystemRepresentation
+                            ) == 0) {
+                            completed = true;
+                            return;
+                        }
+                    } else {
+                        if (exclusive_rename(
+                                coordinated_source,
+                                coordinated_destination,
+                                &operation_error
+                            )) {
+                            completed = true;
+                            return;
+                        }
+                        if ([operation_error.domain isEqualToString:NSCocoaErrorDomain] &&
+                            operation_error.code == NSFileWriteFileExistsError) {
+                            return;
+                        }
                     }
 
                     NSURL *destination_directory = coordinated_destination
@@ -122,30 +162,36 @@ bool finalize_file(
                         return;
                     }
 
-                    const auto coordinated_destination_exists = [file_manager
-                        fileExistsAtPath:coordinated_destination.path];
-                    if (coordinated_destination_exists) {
-                        if (!replaces_existing) {
-                            operation_error = file_exists_error(coordinated_destination);
+                    if (!replaces_existing) {
+                        if (!exclusive_rename(
+                                staging_url,
+                                coordinated_destination,
+                                &operation_error
+                            )) {
                             [file_manager removeItemAtURL:staging_url error:nil];
                             return;
                         }
-                        if (![file_manager
-                                replaceItemAtURL:coordinated_destination
-                                withItemAtURL:staging_url
-                                backupItemName:nil
-                                options:0
-                                resultingItemURL:nil
-                                error:&operation_error]) {
+                    } else {
+                        const auto coordinated_destination_exists = [file_manager
+                            fileExistsAtPath:coordinated_destination.path];
+                        if (coordinated_destination_exists) {
+                            if (![file_manager
+                                    replaceItemAtURL:coordinated_destination
+                                    withItemAtURL:staging_url
+                                    backupItemName:nil
+                                    options:0
+                                    resultingItemURL:nil
+                                    error:&operation_error]) {
+                                [file_manager removeItemAtURL:staging_url error:nil];
+                                return;
+                            }
+                        } else if (![file_manager
+                                       moveItemAtURL:staging_url
+                                       toURL:coordinated_destination
+                                       error:&operation_error]) {
                             [file_manager removeItemAtURL:staging_url error:nil];
                             return;
                         }
-                    } else if (![file_manager
-                                   moveItemAtURL:staging_url
-                                   toURL:coordinated_destination
-                                   error:&operation_error]) {
-                        [file_manager removeItemAtURL:staging_url error:nil];
-                        return;
                     }
 
                     // The destination is committed at this point, so a sandbox

--- a/Packages/SDMCore/Sources/SDMEngine/FileFinalizer.mm
+++ b/Packages/SDMCore/Sources/SDMEngine/FileFinalizer.mm
@@ -1,0 +1,175 @@
+#import <Foundation/Foundation.h>
+
+#include "SDMFileFinalizer.h"
+
+#include <cstdio>
+#include <string>
+
+namespace {
+
+std::string error_description(NSError *error) {
+    if (error == nil) {
+        return "The destination could not be written.";
+    }
+    const auto *description = error.localizedDescription.UTF8String;
+    return description == nullptr
+        ? "The destination could not be written."
+        : std::string(description);
+}
+
+NSError *file_exists_error(NSURL *destination) {
+    return [NSError errorWithDomain:NSCocoaErrorDomain
+                               code:NSFileWriteFileExistsError
+                           userInfo:@{NSFilePathErrorKey: destination.path}];
+}
+
+bool synchronize_file(NSURL *url, NSError **error) {
+    NSFileHandle *handle = [NSFileHandle fileHandleForWritingToURL:url error:error];
+    if (handle == nil) {
+        return false;
+    }
+    const auto synchronized = [handle synchronizeAndReturnError:error];
+    NSError *close_error = nil;
+    const auto closed = [handle closeAndReturnError:&close_error];
+    if (!synchronized) {
+        return false;
+    }
+    if (!closed) {
+        if (error != nullptr) {
+            *error = close_error;
+        }
+        return false;
+    }
+    return true;
+}
+
+} // namespace
+
+namespace sdm {
+
+bool finalize_file(
+    const std::filesystem::path &source,
+    const std::filesystem::path &destination,
+    bool replaces_existing,
+    std::string &error_message
+) noexcept {
+    @autoreleasepool {
+        @try {
+            const auto source_string = source.string();
+            const auto destination_string = destination.string();
+            NSString *source_path = [NSString stringWithUTF8String:source_string.c_str()];
+            NSString *destination_path = [NSString
+                stringWithUTF8String:destination_string.c_str()];
+            if (source_path == nil || destination_path == nil) {
+                error_message = "The source or destination path is not valid UTF-8.";
+                return false;
+            }
+
+            NSURL *source_url = [NSURL fileURLWithPath:source_path isDirectory:NO];
+            NSURL *destination_url = [NSURL
+                fileURLWithPath:destination_path
+                isDirectory:NO];
+            NSFileCoordinator *coordinator = [[NSFileCoordinator alloc]
+                initWithFilePresenter:nil];
+            __block NSError *operation_error = nil;
+            __block bool completed = false;
+            NSError *coordination_error = nil;
+            const auto writing_options = replaces_existing
+                ? NSFileCoordinatorWritingForReplacing
+                : static_cast<NSFileCoordinatorWritingOptions>(0);
+
+            [coordinator
+                coordinateReadingItemAtURL:source_url
+                options:NSFileCoordinatorReadingWithoutChanges
+                writingItemAtURL:destination_url
+                options:writing_options
+                error:&coordination_error
+                byAccessor:^(NSURL *coordinated_source, NSURL *coordinated_destination) {
+                    NSFileManager *file_manager = [[NSFileManager alloc] init];
+                    const auto destination_exists = [file_manager
+                        fileExistsAtPath:coordinated_destination.path];
+                    if (destination_exists && !replaces_existing) {
+                        operation_error = file_exists_error(coordinated_destination);
+                        return;
+                    }
+
+                    if (::rename(
+                            coordinated_source.fileSystemRepresentation,
+                            coordinated_destination.fileSystemRepresentation
+                        ) == 0) {
+                        completed = true;
+                        return;
+                    }
+
+                    NSURL *destination_directory = coordinated_destination
+                        .URLByDeletingLastPathComponent;
+                    NSString *staging_name = [NSString stringWithFormat:
+                        @".%@.%@.sdm-export",
+                        coordinated_destination.lastPathComponent,
+                        NSUUID.UUID.UUIDString];
+                    NSURL *staging_url = [destination_directory
+                        URLByAppendingPathComponent:staging_name
+                        isDirectory:NO];
+
+                    if (![file_manager
+                            copyItemAtURL:coordinated_source
+                            toURL:staging_url
+                            error:&operation_error]) {
+                        return;
+                    }
+                    if (!synchronize_file(staging_url, &operation_error)) {
+                        [file_manager removeItemAtURL:staging_url error:nil];
+                        return;
+                    }
+
+                    const auto coordinated_destination_exists = [file_manager
+                        fileExistsAtPath:coordinated_destination.path];
+                    if (coordinated_destination_exists) {
+                        if (!replaces_existing) {
+                            operation_error = file_exists_error(coordinated_destination);
+                            [file_manager removeItemAtURL:staging_url error:nil];
+                            return;
+                        }
+                        if (![file_manager
+                                replaceItemAtURL:coordinated_destination
+                                withItemAtURL:staging_url
+                                backupItemName:nil
+                                options:0
+                                resultingItemURL:nil
+                                error:&operation_error]) {
+                            [file_manager removeItemAtURL:staging_url error:nil];
+                            return;
+                        }
+                    } else if (![file_manager
+                                   moveItemAtURL:staging_url
+                                   toURL:coordinated_destination
+                                   error:&operation_error]) {
+                        [file_manager removeItemAtURL:staging_url error:nil];
+                        return;
+                    }
+
+                    // The destination is committed at this point, so a sandbox
+                    // cleanup failure must not turn a successful save into a retry.
+                    [file_manager removeItemAtURL:coordinated_source error:nil];
+                    completed = true;
+                }];
+
+            if (completed) {
+                error_message.clear();
+                return true;
+            }
+            error_message = error_description(
+                coordination_error == nil ? operation_error : coordination_error
+            );
+            return false;
+        } @catch (NSException *exception) {
+            const auto *reason = exception.reason.UTF8String;
+            error_message = reason == nullptr
+                ? "File coordination failed."
+                : std::string(reason);
+            return false;
+        }
+    }
+}
+
+} // namespace sdm

--- a/Packages/SDMCore/Sources/SDMEngine/StateMachine.cpp
+++ b/Packages/SDMCore/Sources/SDMEngine/StateMachine.cpp
@@ -71,7 +71,8 @@ Result validate_command(DownloadState state, CommandKind command) noexcept {
             : Result::invalid_state;
     case CommandKind::cancel:
         return state != DownloadState::completed &&
-                state != DownloadState::cancelled
+                state != DownloadState::cancelled &&
+                state != DownloadState::finalizing
             ? Result::ok
             : Result::invalid_state;
     case CommandKind::retry:

--- a/Packages/SDMCore/Sources/SDMEngine/include/SDMFileFinalizer.h
+++ b/Packages/SDMCore/Sources/SDMEngine/include/SDMFileFinalizer.h
@@ -1,0 +1,21 @@
+#ifndef SDM_FILE_FINALIZER_H
+#define SDM_FILE_FINALIZER_H
+
+#include <filesystem>
+#include <string>
+
+namespace sdm {
+
+/// Moves a completed partial file into its destination while coordinating with
+/// iCloud Drive and File Provider implementations. The source remains intact
+/// when the destination cannot be committed.
+bool finalize_file(
+    const std::filesystem::path &source,
+    const std::filesystem::path &destination,
+    bool replaces_existing,
+    std::string &error_message
+) noexcept;
+
+} // namespace sdm
+
+#endif

--- a/Packages/SDMCore/Sources/SDMEngineBridge/SDMEngineBridge.cpp
+++ b/Packages/SDMCore/Sources/SDMEngineBridge/SDMEngineBridge.cpp
@@ -1,6 +1,7 @@
 #include "SDMEngineBridge.h"
 
 #include "SDMEngine.h"
+#include "SDMFileFinalizer.h"
 
 #include <curl/curl.h>
 
@@ -101,6 +102,19 @@ void copy_segment(const sdm::Segment &source, sdm_segment_snapshot_t &destinatio
     destination.next = source.next;
 }
 
+void copy_error_message(
+    char *destination,
+    std::size_t capacity,
+    const std::string &source
+) {
+    if (destination == nullptr || capacity == 0) {
+        return;
+    }
+    const auto count = std::min(source.size(), capacity - 1);
+    std::memcpy(destination, source.data(), count);
+    destination[count] = '\0';
+}
+
 } // namespace
 
 uint32_t sdm_engine_abi_version(void) {
@@ -113,6 +127,39 @@ const char *sdm_engine_version(void) {
 
 const char *sdm_curl_version(void) {
     return curl_version();
+}
+
+sdm_result_t sdm_finalize_file(
+    sdm_string_view_t source_path,
+    sdm_string_view_t destination_path,
+    uint8_t replaces_existing,
+    char *error_message,
+    size_t error_message_capacity
+) {
+    if (source_path.length == 0 || destination_path.length == 0 ||
+        error_message == nullptr || error_message_capacity == 0) {
+        return SDM_RESULT_INVALID_ARGUMENT;
+    }
+    try {
+        std::string message;
+        const auto finalized = sdm::finalize_file(
+            copy_string(source_path),
+            copy_string(destination_path),
+            replaces_existing != 0,
+            message
+        );
+        copy_error_message(error_message, error_message_capacity, message);
+        return finalized ? SDM_RESULT_OK : SDM_RESULT_IO_ERROR;
+    } catch (const std::invalid_argument &) {
+        return SDM_RESULT_INVALID_ARGUMENT;
+    } catch (...) {
+        copy_error_message(
+            error_message,
+            error_message_capacity,
+            "File finalization failed."
+        );
+        return SDM_RESULT_INTERNAL_ERROR;
+    }
 }
 
 sdm_result_t sdm_engine_create(

--- a/Packages/SDMCore/Sources/SDMEngineBridge/include/SDMEngineBridge.h
+++ b/Packages/SDMCore/Sources/SDMEngineBridge/include/SDMEngineBridge.h
@@ -133,6 +133,14 @@ uint32_t sdm_engine_abi_version(void);
 const char *sdm_engine_version(void);
 const char *sdm_curl_version(void);
 
+sdm_result_t sdm_finalize_file(
+    sdm_string_view_t source_path,
+    sdm_string_view_t destination_path,
+    uint8_t replaces_existing,
+    char *error_message,
+    size_t error_message_capacity
+);
+
 sdm_result_t sdm_engine_create(
     const sdm_engine_config_t *config,
     sdm_engine_t **out_engine

--- a/Packages/SDMCore/Tests/SDMCoreTests/DownloadModelsTests.swift
+++ b/Packages/SDMCore/Tests/SDMCoreTests/DownloadModelsTests.swift
@@ -65,6 +65,7 @@ final class DownloadModelsTests: XCTestCase {
 
         XCTAssertEqual(sdm_test_validate_command(3, 1), 0)
         XCTAssertEqual(sdm_test_validate_command(8, 1), 3)
+        XCTAssertEqual(sdm_test_validate_command(7, 1), 3)
         XCTAssertEqual(sdm_test_validate_command(5, 2), 0)
     }
 

--- a/Packages/SDMCore/Tests/SDMCoreTests/URLSessionBackendTests.swift
+++ b/Packages/SDMCore/Tests/SDMCoreTests/URLSessionBackendTests.swift
@@ -3,6 +3,23 @@ import XCTest
 @testable import SDMCore
 
 final class URLSessionBackendTests: XCTestCase {
+    func testURLSessionDelegateTaskTrackerWaitsForTerminalOperations() async {
+        let tracker = URLSessionDelegateTaskTracker()
+        let recorder = URLSessionDelegateEventRecorder()
+
+        tracker.start {
+            try? await Task.sleep(for: .milliseconds(50))
+            await recorder.append(1)
+        }
+        tracker.start {
+            await recorder.append(2)
+        }
+        await tracker.waitForTrackedTasks()
+
+        let values = await recorder.values
+        XCTAssertEqual(Set(values), [1, 2])
+    }
+
     func testCoordinatedFinalizerRefusesToOverwriteWithoutReplacePolicy() throws {
         let root = FileManager.default.temporaryDirectory.appending(
             path: UUID().uuidString,
@@ -307,5 +324,13 @@ final class URLSessionBackendTests: XCTestCase {
             XCTAssertEqual(error.code, .invalidArgument)
         }
         await manager.shutdown()
+    }
+}
+
+private actor URLSessionDelegateEventRecorder {
+    private(set) var values: [Int] = []
+
+    func append(_ value: Int) {
+        values.append(value)
     }
 }

--- a/Packages/SDMCore/Tests/SDMCoreTests/URLSessionBackendTests.swift
+++ b/Packages/SDMCore/Tests/SDMCoreTests/URLSessionBackendTests.swift
@@ -3,6 +3,51 @@ import XCTest
 @testable import SDMCore
 
 final class URLSessionBackendTests: XCTestCase {
+    func testCoordinatedFinalizerRefusesToOverwriteWithoutReplacePolicy() throws {
+        let root = FileManager.default.temporaryDirectory.appending(
+            path: UUID().uuidString,
+            directoryHint: .isDirectory
+        )
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let source = root.appending(path: "source.bin")
+        let destination = root.appending(path: "destination.bin")
+        try Data("new".utf8).write(to: source)
+        try Data("old".utf8).write(to: destination)
+
+        XCTAssertThrowsError(
+            try CoordinatedFileFinalizer.move(
+                from: source,
+                to: destination,
+                replacesExisting: false
+            )
+        )
+        XCTAssertEqual(try Data(contentsOf: source), Data("new".utf8))
+        XCTAssertEqual(try Data(contentsOf: destination), Data("old".utf8))
+    }
+
+    func testCoordinatedFinalizerReplacesCommittedDestination() throws {
+        let root = FileManager.default.temporaryDirectory.appending(
+            path: UUID().uuidString,
+            directoryHint: .isDirectory
+        )
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let source = root.appending(path: "source.bin")
+        let destination = root.appending(path: "destination.bin")
+        try Data("new".utf8).write(to: source)
+        try Data("old".utf8).write(to: destination)
+
+        try CoordinatedFileFinalizer.move(
+            from: source,
+            to: destination,
+            replacesExisting: true
+        )
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: source.path))
+        XCTAssertEqual(try Data(contentsOf: destination), Data("new".utf8))
+    }
+
     func testURLSessionDownloadIsByteCorrect() async throws {
         let fixture = try FixtureServer(fileSize: 48 * 1024)
         defer { fixture.stop() }


### PR DESCRIPTION
## Summary

- add configurable macOS save locations for App Sandbox, Downloads Folder (`~/Downloads`), and a custom folder
- migrate the removed `~/Downloads/SDM` choice to Downloads Folder
- add iOS support for selecting an external Files or iCloud Drive folder as the default destination
- persist security-scoped bookmarks with explicit ownership for defaults and individual downloads
- coordinate final file commits for URLSession and libcurl without blocking the curl event loop or completing iOS background events too early
- commit files atomically without overwriting an existing destination

## Why

The original Downloads option exposed the sandbox container path instead of clearly distinguishing the sandbox location from the user Downloads folder. iOS also had no persistent way to choose a Files provider destination. Provider-backed finalization additionally needed to remain responsive, lifecycle-safe, and atomic.

## User impact

macOS users can choose App Sandbox, Downloads Folder, or Custom Folder. The selected current folder is shown as an actual path. Existing `downloadsSDM` preferences automatically fall back to Downloads Folder without deleting files. iOS users can choose an external folder through the Files picker and retain access across launches.

## Review follow-up

- move cross-volume and File Provider finalization off the sole libcurl event loop
- wait for terminal URLSession delegate work before invoking the iOS background-session completion handler
- prevent cancellation after a transfer enters finalization
- use exclusive atomic commits for no-clobber behavior
- prune ownerless one-off bookmarks while retaining saved custom defaults

## Validation

- `bash Scripts/test.sh`
  - Safari extension: 8 passed
  - Chrome extension: 5 passed
  - Fixture: 19 passed
  - SDMCore: 39 passed
- macOS App test suite: 32 passed
- macOS App clean build passed
- iOS Simulator build passed
- manually verified the macOS location menu and migration from `~/Downloads/SDM` to Downloads Folder
- manually downloaded a deterministic 1 MiB fixture to an iOS Files provider folder using 8 libcurl ranges; the completed file matched the expected SHA-256 byte-for-byte and left no sandbox copy